### PR TITLE
Added footer with about-type links.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "express": "^4.14.0",
     "isomorphic-fetch": "^2.2.1",
     "jsdom": "^9.4.1",
-    "opds-web-client": "0.0.25",
+    "opds-web-client": "0.0.26",
     "react": "^15.3.0",
     "react-bootstrap": "^0.29.5",
     "react-dom": "^15.3.0",

--- a/src/components/CatalogHandler.tsx
+++ b/src/components/CatalogHandler.tsx
@@ -4,6 +4,7 @@ import { State } from "opds-web-client/lib/state";
 import { Router, Route, browserHistory } from "react-router";
 const OPDSCatalog = require("opds-web-client");
 import Header from "./Header";
+import Footer from "./Footer";
 import BookDetailsContainer from "./BookDetailsContainer";
 import { NavigateContext } from "opds-web-client/lib/interfaces";
 import computeBreadcrumbs from "../computeBreadcrumbs";
@@ -52,6 +53,7 @@ export default class CatalogHandler extends React.Component<CatalogHandlerProps,
         collectionUrl={collectionUrl}
         bookUrl={bookUrl}
         Header={Header}
+        Footer={Footer}
         BookDetailsContainer={BookDetailsContainer}
         pageTitleTemplate={pageTitleTemplate}
         computeBreadcrumbs={computeBreadcrumbs}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,7 +22,7 @@ export default class Footer extends React.Component<FooterProps, any> {
     Object.keys(labels).forEach(type => {
       let link = this.props.collection.links.find(link => link.type === type);
       if (link) {
-        let linkWithLabel = Object.assign({ text: labels[type] }, link);
+        let linkWithLabel = Object.assign({}, link, { text: labels[type] });
         links.push(linkWithLabel);
       }
     });

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { FooterProps } from "opds-web-client/lib/components/Root";
+import { LinkData } from "opds-web-client/lib/interfaces";
+
+export default class Footer extends React.Component<FooterProps, any> {
+
+  constructor(props) {
+    super(props);
+    this.links = this.links.bind(this);
+  }
+
+  links(): LinkData[] {
+    let links = [];
+
+    let labels = {
+      "about": "About",
+      "terms-of-service": "Terms of Service",
+      "privacy-policy": "Privacy Policy",
+      "copyright": "Copyright"
+    };
+
+    Object.keys(labels).forEach(type => {
+      let link = this.props.collection.links.find(link => link.type === type);
+      if (link) {
+        let linkWithLabel = Object.assign({ text: labels[type] }, link);
+        links.push(linkWithLabel);
+      }
+    });
+    return links;
+  }
+
+  render(): JSX.Element {
+    return (
+      <ul aria-label="about links" className="list-inline">
+        { this.links().map(link =>
+          <li key={link.url} style={{padding: "5px"}}>
+            <a href={link.url} target="_blank">{link.text}</a>
+          </li>
+        ) }
+      </ul>
+    );
+  }
+}

--- a/src/components/__tests__/CatalogHandler-test.tsx
+++ b/src/components/__tests__/CatalogHandler-test.tsx
@@ -41,6 +41,7 @@ describe("CatalogHandler", () => {
     expect(catalog.prop("collectionUrl")).to.equal(host + "/collectionurl");
     expect(catalog.prop("bookUrl")).to.equal(host + "/works/bookurl");
     expect(catalog.prop("Header").name).to.equal("Header");
+    expect(catalog.prop("Footer").name).to.equal("Footer");
     expect(catalog.prop("BookDetailsContainer").name).to.equal("BookDetailsContainer");
     expect(catalog.prop("initialState")).to.equal(store.getState());
     expect(catalog.prop("computeBreadcrumbs")).to.be.ok;

--- a/src/components/__tests__/Footer-test.tsx
+++ b/src/components/__tests__/Footer-test.tsx
@@ -1,0 +1,42 @@
+import { expect } from "chai";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import Footer from "../Footer";
+
+describe("Footer", () => {
+  let wrapper;
+  let collection = {
+    id: "collection",
+    title: "Collection",
+    url: "Collection",
+    lanes: [],
+    books: [],
+    navigationLinks: [],
+    links: [
+      { url: "about", type: "about", text: null },
+      { url: "terms", type: "terms-of-service", text: null },
+      { url: "unknown", type: "unknown", text: null }
+    ]
+  };
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <Footer
+        collection={collection}
+        />
+    );
+  });
+
+  describe("rendering", () => {
+    it("displays links", () => {
+      let links = wrapper.find("a");
+      expect(links.length).to.equal(2);
+      let aboutLink = links.at(0);
+      let termsLink = links.at(1);
+      expect(aboutLink.props().href).to.equal("about");
+      expect(termsLink.props().href).to.equal("terms");
+    });
+  });
+});

--- a/src/components/__tests__/Footer-test.tsx
+++ b/src/components/__tests__/Footer-test.tsx
@@ -15,7 +15,7 @@ describe("Footer", () => {
     books: [],
     navigationLinks: [],
     links: [
-      { url: "about", type: "about", text: null },
+      { url: "about", type: "about", text: "abcd" },
       { url: "terms", type: "terms-of-service", text: null },
       { url: "unknown", type: "unknown", text: null }
     ]
@@ -37,6 +37,8 @@ describe("Footer", () => {
       let termsLink = links.at(1);
       expect(aboutLink.props().href).to.equal("about");
       expect(termsLink.props().href).to.equal("terms");
+      expect(aboutLink.text()).to.equal("About");
+      expect(termsLink.text()).to.equal("Terms of Service");
     });
   });
 });


### PR DESCRIPTION
This fixes #22. 

I moved the code to handle the specific link types here from https://github.com/NYPL-Simplified/opds-web-client/pull/153.