### PR TITLE
Fix #43

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "express": "^4.14.0",
     "isomorphic-fetch": "^2.2.1",
     "jsdom": "^9.4.1",
-    "opds-web-client": "0.1.8",
+    "opds-web-client": "0.1.9",
     "react": "^15.3.0",
     "react-bootstrap": "^0.29.5",
     "react-dom": "^15.3.0",

--- a/src/__tests__/computeBreadcrumbs-test.tsx
+++ b/src/__tests__/computeBreadcrumbs-test.tsx
@@ -1,0 +1,57 @@
+import { expect } from "chai";
+
+import computeBreadcrumbs from "../computeBreadcrumbs";
+
+describe("computeBreadcrumbs", () => {
+  let collection = {
+    id: "id",
+    url: "url",
+    title: "title",
+    lanes: [],
+    books: [],
+    navigationLinks: []
+  };
+  let history = [];
+
+  it("uses breadcrumbs if they're in the raw collection data", () => {
+    let raw = {
+      "simplified:breadcrumbs": [{
+        link: [{
+          "$": {
+            href: { value: "breadcrumb url" },
+            title: { value: "breadcrumb title" }
+          }
+        }]
+      }]
+    };
+    let data = Object.assign({}, collection, { raw });
+    let expected = [
+      { url: "breadcrumb url", text: "breadcrumb title" },
+      { url: collection.url, text: collection.title }
+    ];
+    expect(computeBreadcrumbs(data, history)).to.deep.equal(expected);
+  });
+
+  it("ignores trailing slashes when using hierarchyComputeBreadcrumbs", () => {
+    let catalogRootLink = {
+      url: "url/",
+      text: "text"
+    };
+
+    let data = Object.assign({}, collection, { catalogRootLink });
+    let expected = [{ url: collection.url, text: collection.title }];
+    expect(computeBreadcrumbs(data, history)).to.deep.equal(expected);
+
+    catalogRootLink = {
+      url: "different url/",
+      text: "text"
+    };
+
+    data = Object.assign({}, collection, { catalogRootLink });
+    expected = [
+      catalogRootLink,
+      { url: collection.url, text: collection.title }
+    ];
+    expect(computeBreadcrumbs(data, history)).to.deep.equal(expected);
+  });
+});

--- a/src/computeBreadcrumbs.tsx
+++ b/src/computeBreadcrumbs.tsx
@@ -1,6 +1,17 @@
 import { CollectionData, LinkData } from "opds-web-client/lib/interfaces";
 import { hierarchyComputeBreadcrumbs } from "opds-web-client/lib/components/Breadcrumbs";
 
+// Custom URL comparator to ignore trailing slashes.
+let urlComparator = (url1: string , url2: string): boolean => {
+  if (url1.endsWith("/")) {
+    url1 = url1.slice(0, -1);
+  }
+  if (url2.endsWith("/")) {
+    url2 = url2.slice(0, -1);
+  }
+  return url1 === url2;
+};
+
 export default (collection: CollectionData, history: LinkData[]): LinkData[] => {
   let links = [];
 
@@ -22,7 +33,7 @@ export default (collection: CollectionData, history: LinkData[]): LinkData[] => 
       text: collection.title
     });
   } else {
-    links = hierarchyComputeBreadcrumbs(collection, history);
+    links = hierarchyComputeBreadcrumbs(collection, history, urlComparator);
   }
 
   return links;


### PR DESCRIPTION
This branch adds a URL comparator for breadcrumbs that ignores trailing slashes, using https://github.com/NYPL-Simplified/opds-web-client/pull/179. 

Tests should be failing until the new version of opds-web-client is published.