### PR TITLE
Updated redux and react-redux and switched to typings from dt.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "react": "^15.3.0",
     "react-bootstrap": "^0.29.5",
     "react-dom": "^15.3.0",
-    "react-redux": "^4.4.5",
+    "react-redux": "^4.4.6",
     "react-router": "^2.5.2",
-    "redux": "^3.5.2",
+    "redux": "^3.6.0",
     "redux-thunk": "^2.1.0"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "chai": "registry:npm/chai#3.5.0+20160723033700",
     "enzyme": "registry:npm/enzyme#2.2.0+20160322031343",
-    "react-redux": "registry:npm/react-redux#4.4.0+20160614222153",
     "sinon": "registry:npm/sinon#1.16.0+20160723033700"
   },
   "globalDependencies": {
@@ -18,8 +17,10 @@
     "react": "registry:dt/react#0.14.0+20160630100702",
     "react-bootstrap": "registry:dt/react-bootstrap#0.0.0+20160706182032",
     "react-dom": "registry:dt/react-dom#0.14.0+20160412154040",
+    "react-redux": "registry:dt/react-redux#4.4.0+20160908183346",
     "react-router": "registry:dt/react-router#2.0.0+20160621215300",
     "react-router/history": "registry:dt/react-router/history#2.0.0+20160608102730",
+    "redux": "registry:dt/redux#3.5.2+20160703092728",
     "serve-static": "registry:dt/serve-static#0.0.0+20160606155157"
   }
 }


### PR DESCRIPTION
I'm hoping this will fix an issue with jenkins where the first build after a code update fails to find redux. We were already using the typings from dt in opds-web-client.

One weird thing is that redux has its own typings, but they don't seem to get picked up by the react-redux typings, so I also needed redux typings from dt.