### PR TITLE
Instant Classics compatibility

### DIFF
--- a/config/instantclassics.json
+++ b/config/instantclassics.json
@@ -1,13 +1,8 @@
 {
-  "theme": "./src/themes/openebooks.scss",
-  "homeUrl": "/groups/",
-  "catalogBase": "http://qa.circulation.openebooks.us",
-  "catalogName": "Open eBooks",
-  "appName": "Open eBooks",
-  "authPlugins": {
-    "FirstBook": "./src/auth/FirstBookAuthPlugin.ts",
-    "Clever": "./src/auth/CleverAuthPlugin.ts"
-  },
+  "theme": "./src/themes/instantclassics.scss",
+  "homeUrl": "/https%3A%2F%2Finstantclassics.librarysimplified.org%2Findex.xml",
+  "catalogBase": "https://instantclassics.librarysimplified.org",
+  "catalogName": "Instant Classics",
   "headerLinks": [
     { "title": "Home", "url": "http://openebooks.net/index.html" },
     { "title": "About", "url": "http://openebooks.net/about.html" },
@@ -16,5 +11,6 @@
     { "title": "Help Center", "url": "https://openebooks.zendesk.com/" },
     { "title": "Catalog", "url": "http://openebooks.net/catalog.html" }
   ],
-  "logoLink": "http://openebooks.net/index.html"
+  "logoLink": "http://openebooks.net/index.html",
+  "shortenUrls": false
 }

--- a/config/local.openebooks.json
+++ b/config/local.openebooks.json
@@ -13,7 +13,8 @@
     { "title": "About", "url": "http://openebooks.net/about.html" },
     { "title": "Contribute","url": "http://openebooks.net/contribute.html" },
     { "title": "Resources", "url": "http://openebooks.net/resources.html" },
-    { "title": "Help Center", "url": "https://openebooks.zendesk.com/" }
+    { "title": "Help Center", "url": "https://openebooks.zendesk.com/" },
+    { "title": "Catalog", "url": "http://openebooks.net/catalog.html" }
   ],
   "logoLink": "http://openebooks.net/index.html"
 }

--- a/config/production.openebooks.json
+++ b/config/production.openebooks.json
@@ -13,7 +13,8 @@
     { "title": "About", "url": "http://openebooks.net/about.html" },
     { "title": "Contribute","url": "http://openebooks.net/contribute.html" },
     { "title": "Resources", "url": "http://openebooks.net/resources.html" },
-    { "title": "Help Center", "url": "https://openebooks.zendesk.com/" }
+    { "title": "Help Center", "url": "https://openebooks.zendesk.com/" },
+    { "title": "Catalog", "url": "http://openebooks.net/catalog.html" }
   ],
   "logoLink": "http://openebooks.net/index.html"
 }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -17,6 +17,7 @@ interface Config {
   };
   headerLinks?: HeaderLink[];
   logoLink?: URLString;
+  shortenUrls?: boolean;
 }
 
 export default Config;

--- a/src/components/CatalogHandler.tsx
+++ b/src/components/CatalogHandler.tsx
@@ -24,6 +24,7 @@ export interface CatalogHandlerContext {
   catalogBase: string;
   catalogName: string;
   authPlugins: AuthPlugin[];
+  shortenUrls: boolean;
   initialState?: State;
 }
 
@@ -35,14 +36,17 @@ export default class CatalogHandler extends React.Component<CatalogHandlerProps,
     catalogBase: React.PropTypes.string.isRequired,
     catalogName: React.PropTypes.string.isRequired,
     authPlugins: React.PropTypes.array.isRequired,
+    shortenUrls: React.PropTypes.bool.isRequired,
     initialState: React.PropTypes.object
   };
 
   render() {
     let { collectionUrl, bookUrl } = this.props.params;
 
-    collectionUrl = expandCollectionUrl(this.context.catalogBase, collectionUrl) || null;
-    bookUrl = expandBookUrl(this.context.catalogBase, bookUrl) || null;
+    if (this.context.shortenUrls) {
+      collectionUrl = expandCollectionUrl(this.context.catalogBase, collectionUrl) || null;
+      bookUrl = expandBookUrl(this.context.catalogBase, bookUrl) || null;
+    }
 
     let pageTitleTemplate = (collectionTitle, bookTitle) => {
       let details = bookTitle || collectionTitle;

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -15,6 +15,7 @@ export interface ContextProviderProps extends React.Props<any> {
   authPlugins: AuthPlugin[];
   headerLinks: HeaderLink[];
   logoLink: string;
+  shortenUrls: boolean;
   initialState?: CatalogState;
 }
 
@@ -40,15 +41,17 @@ export default class ContextProvider extends React.Component<ContextProviderProp
   }
 
   prepareCollectionUrl(url: string): string {
-    return encodeURIComponent(
-      url.replace(this.props.catalogBase + "/", "").replace(/\/$/, "").replace(/^\//, "")
-    );
+    if (this.props.shortenUrls) {
+      url = url.replace(this.props.catalogBase + "/", "").replace(/\/$/, "").replace(/^\//, "");
+    }
+    return encodeURIComponent(url);
   }
 
   prepareBookUrl(url: string): string {
-    return encodeURIComponent(
-      url.replace(this.props.catalogBase + "/works/", "").replace(/\/$/, "").replace(/^\//, "")
-    );
+    if (this.props.shortenUrls) {
+      url = url.replace(this.props.catalogBase + "/works/", "").replace(/\/$/, "").replace(/^\//, "");
+    }
+    return encodeURIComponent(url);
   }
 
   static childContextTypes: React.ValidationMap<any> = {
@@ -61,6 +64,7 @@ export default class ContextProvider extends React.Component<ContextProviderProp
     authPlugins: React.PropTypes.array.isRequired,
     headerLinks: React.PropTypes.array.isRequired,
     logoLink: React.PropTypes.string.isRequired,
+    shortenUrls: React.PropTypes.bool.isRequired,
     initialState: React.PropTypes.object
   };
 
@@ -75,6 +79,7 @@ export default class ContextProvider extends React.Component<ContextProviderProp
       authPlugins: this.props.authPlugins,
       headerLinks: this.props.headerLinks,
       logoLink: this.props.logoLink,
+      shortenUrls: this.props.shortenUrls,
       initialState: this.props.initialState
     };
   }

--- a/src/components/__tests__/CatalogHandler-test.tsx
+++ b/src/components/__tests__/CatalogHandler-test.tsx
@@ -33,17 +33,19 @@ describe("CatalogHandler", () => {
       catalogBase: host,
       catalogName: name,
       authPlugins: authPlugins,
+      shortenUrls: true,
       initialState: store.getState()
     };
+  });
+
+  it("renders OPDSCatalog with shortened urls", () => {
     wrapper = shallow(
       <CatalogHandler
         params={params}
         />,
       { context }
     );
-  });
 
-  it("renders OPDSCatalog", () => {
     let catalog = wrapper.find(OPDSCatalog);
     expect(catalog.prop("collectionUrl")).to.equal(host + "/collectionurl");
     expect(catalog.prop("bookUrl")).to.equal(host + "/works/bookurl");
@@ -56,5 +58,19 @@ describe("CatalogHandler", () => {
     let pageTitleTemplate = catalog.prop("pageTitleTemplate");
     expect(pageTitleTemplate("Collection", "Book")).to.equal("Example - Book");
     expect(pageTitleTemplate("Collection", null)).to.equal("Example - Collection");
+  });
+
+  it("renders OPDSCatalog with full urls", () => {
+    context.shortenUrls = false;
+    wrapper = shallow(
+      <CatalogHandler
+        params={params}
+        />,
+      { context }
+    );
+
+    let catalog = wrapper.find(OPDSCatalog);
+    expect(catalog.prop("collectionUrl")).to.equal("collectionurl");
+    expect(catalog.prop("bookUrl")).to.equal("bookurl");
   });
 });

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -25,6 +25,7 @@ describe("ContextProvider", () => {
     url: "http://faq"
   }];
   let logoLink = "http://home";
+  let shortenUrls = true;
 
   beforeEach(() => {
     store = buildStore();
@@ -37,6 +38,7 @@ describe("ContextProvider", () => {
         authPlugins={authPlugins}
         headerLinks={headerLinks}
         logoLink={logoLink}
+        shortenUrls={shortenUrls}
         initialState={store.getState()}>
         <TestComponent />
       </ContextProvider>
@@ -61,7 +63,7 @@ describe("ContextProvider", () => {
     expect(children.length).to.equal(1);
   });
 
-  describe("pathFor", () => {
+  describe("pathFor with url shortening", () => {
     let collectionUrl = "collection/url";
     let bookUrl = "book/url";
     let host = "http://example.com";
@@ -100,6 +102,39 @@ describe("ContextProvider", () => {
     it("returns a path with no collection or book", () => {
       let path = wrapper.instance().pathFor(null, null);
       expect(path).to.equal(``);
+    });
+  });
+
+  describe("pathFor without url shortening", () => {
+    let collectionUrl = "collection/url";
+    let bookUrl = "book/url";
+    let host = "http://example.com";
+
+    beforeEach(() => {
+      wrapper = shallow(
+        <ContextProvider
+          homeUrl={homeUrl}
+          catalogBase={catalogBase}
+          catalogName={catalogName}
+          appName={appName}
+          authPlugins={authPlugins}
+          headerLinks={headerLinks}
+          logoLink={logoLink}
+          shortenUrls={false}
+          initialState={store.getState()}>
+          <TestComponent />
+        </ContextProvider>
+      );
+    });
+
+    it("encodes collection url", () => {
+      let url = host + "/groups/eng/Adult%20Fiction";
+      expect(wrapper.instance().prepareCollectionUrl(url)).to.equal(encodeURIComponent(url));
+    });
+
+    it("encodes book url", () => {
+      let url = host + "/works/Axis%20360/Axis%20360%20ID/0016201449";
+      expect(wrapper.instance().prepareBookUrl(url)).to.equal(encodeURIComponent(url));
     });
   });
 });

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -28,6 +28,7 @@ const distDir = process.env.SIMPLIFIED_PATRON_DIST || "dist";
 const authPlugins = Object.keys(config.authPlugins || {});
 const headerLinks = config.headerLinks || [];
 const logoLink = config.logoLink || "";
+const shortenUrls = config.shortenUrls !== undefined ? config.shortenUrls : true;
 
 const authPluginJsTags = authPlugins.map(plugin => {
   return `<script src="/js/${plugin}.js"></script>\n`;
@@ -46,8 +47,10 @@ function handleRender(req, res) {
       res.redirect(302, redirectLocation.pathname + redirectLocation.search);
     } else if (renderProps) {
       let { collectionUrl, bookUrl } = renderProps.params;
-      collectionUrl = expandCollectionUrl(catalogBase, collectionUrl);
-      bookUrl = expandBookUrl(catalogBase, bookUrl);
+      if (shortenUrls) {
+        collectionUrl = expandCollectionUrl(catalogBase, collectionUrl);
+        bookUrl = expandBookUrl(catalogBase, bookUrl);
+      }
 
       if (!collectionUrl && !bookUrl) {
         res.redirect(302, "/collection" + homeUrl);
@@ -64,6 +67,7 @@ function handleRender(req, res) {
             authPlugins={[]}
             headerLinks={headerLinks}
             logoLink={logoLink}
+            shortenUrls={shortenUrls}
             initialState={state}>
             <RouterContext {...renderProps} />
           </ContextProvider>
@@ -81,6 +85,7 @@ function handleRender(req, res) {
               authPlugins={[]}
               headerLinks={headerLinks}
               logoLink={logoLink}
+              shortenUrls={shortenUrls}
               initialState={state}>
               <RouterContext {...renderProps} />
             </ContextProvider>
@@ -116,6 +121,7 @@ function renderFullPage(html: string, preloadedState: State) {
             authPlugins: [${authPlugins}],
             headerLinks: ${JSON.stringify(headerLinks)},
             logoLink: "${logoLink}",
+            shortenUrls: ${shortenUrls},
             initialState: ${JSON.stringify(preloadedState)}
           });
         </script>

--- a/src/themes/instantclassics.scss
+++ b/src/themes/instantclassics.scss
@@ -1,0 +1,13 @@
+@import 'openebooks';
+
+.book-details .main .circulation-links .btn {
+  &.download-button {
+    display: block;
+  }
+}
+
+.catalog .navbar {
+  .navbar-nav > li:nth-child(7) {
+    display: none;
+  }
+}

--- a/src/themes/openebooks.scss
+++ b/src/themes/openebooks.scss
@@ -33,6 +33,11 @@ $logo: url('openebooks-logo.png');
     text-decoration: none;
   }
 
+  .navbar-nav > li:nth-child(7) {
+    /* Hide our Catalog link since we have one to the Open eBooks page that links to the two libraries. */
+    display: none;
+  }
+
   .container-fluid, .navbar-header, .navbar-brand {
     height:100%;
   }
@@ -47,7 +52,7 @@ $logo: url('openebooks-logo.png');
     @media(min-width: 768px) {
       float: right;
 
-      @media(max-width: 876px) {
+      @media(max-width: 964px) {
         >li>a {
           padding-left: 7px;
           padding-right: 7px;
@@ -61,6 +66,7 @@ $logo: url('openebooks-logo.png');
   }
 
   .navbar-brand, .navbar-brand:hover {
+    width: 110px;
     background-size: 98px;
     color: transparent;
   }


### PR DESCRIPTION
This branch makes it possible to run the catalog with the instant classics OPDS feed. 

In addition to adding the config file and un-hiding the download buttons, I had to make it possible to turn off URL shortening, since it depends on individual OPDS entries having URLs and instant classics only has feeds.

This branch also assumes that openebooks.net will host a static catalog.html page that links to both the instant classics catalog and the open ebooks catalog. The catalog links in the headers of both these catalogs now point to a URL for the static page, and the original catalog links are hidden.