### PR TITLE
Updated Open eBooks header links.

### DIFF
--- a/config/local.openebooks.json
+++ b/config/local.openebooks.json
@@ -11,10 +11,10 @@
   "headerLinks": [
     { "title": "Home", "url": "http://openebooks.net/index.html" },
     { "title": "About", "url": "http://openebooks.net/about.html" },
-    { "title": "Contribute","url": "http://openebooks.net/contribute.html" },
+    { "title": "FAQs","url": "http://openebooks.net/faq.html" },
     { "title": "Resources", "url": "http://openebooks.net/resources.html" },
     { "title": "Help Center", "url": "https://openebooks.zendesk.com/" },
-    { "title": "Catalog", "url": "http://openebooks.net/catalog.html" }
+    { "title": "Catalog", "url": "/collection/groups" }
   ],
   "logoLink": "http://openebooks.net/index.html"
 }

--- a/config/production.openebooks.json
+++ b/config/production.openebooks.json
@@ -11,10 +11,10 @@
   "headerLinks": [
     { "title": "Home", "url": "http://openebooks.net/index.html" },
     { "title": "About", "url": "http://openebooks.net/about.html" },
-    { "title": "Contribute","url": "http://openebooks.net/contribute.html" },
+    { "title": "FAQs","url": "http://openebooks.net/faq.html" },
     { "title": "Resources", "url": "http://openebooks.net/resources.html" },
     { "title": "Help Center", "url": "https://openebooks.zendesk.com/" },
-    { "title": "Catalog", "url": "http://openebooks.net/catalog.html" }
+    { "title": "Catalog", "url": "/collection/groups" }
   ],
   "logoLink": "http://openebooks.net/index.html"
 }

--- a/config/qa.openebooks.json
+++ b/config/qa.openebooks.json
@@ -11,10 +11,10 @@
   "headerLinks": [
     { "title": "Home", "url": "http://openebooks.net/index.html" },
     { "title": "About", "url": "http://openebooks.net/about.html" },
-    { "title": "Contribute","url": "http://openebooks.net/contribute.html" },
+    { "title": "FAQs","url": "http://openebooks.net/faq.html" },
     { "title": "Resources", "url": "http://openebooks.net/resources.html" },
     { "title": "Help Center", "url": "https://openebooks.zendesk.com/" },
-    { "title": "Catalog", "url": "http://openebooks.net/catalog.html" }
+    { "title": "Catalog", "url": "/collection/groups" }
   ],
   "logoLink": "http://openebooks.net/index.html"
 }


### PR DESCRIPTION
DPLA just updated openebooks.net and this changes the catalog header to match.

We removed the catalog landing page that linked to the broken Instant Classics catalog so now the "Catalog" link goes directly to this Open eBooks catalog, and also replaced "Contribute" with "FAQs".