### PR TITLE
Docker submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docker"]
+	path = docker
+	url = git@github.com:NYPL-Simplified/docker-patron-web.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 
 node_js:
   - "8"
+
+git:
+  submodules: false


### PR DESCRIPTION
This branch adds a submodule for docker, so we can trigger builds in docker hub. It should be configured the same way as the ones for circulation.