### PR TITLE
Remove server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,42 @@
 ## CHANGELOG
 
+### 3.0.0
+
+- removed server to render only with client
+
 ### 1.0.0
+
 #### Updated
+
 - Updated opds-web-client and Typescript to more recent versions.
 - Changed the download buttons to remove duplicate mime types and hide unknown mime types.
 
 #### Added
+
 - The application has a docker submodule and Docker images are now automatically built in Docker hub.
 
 ### 0.2.2
+
 #### Updated
+
 - Updated documentation explaining how to run the application. Added a separate LICENSE file.
 
 ### 0.2.1
+
 #### Added
+
 - `tslint-react-a11y` to review accessibility for React components.
 
 ### 0.2.0
+
 #### Updated
+
 - Updating to React 16.
 
 ### 0.1.0
+
 #### Updated
+
 - Updated packages include Webpack and Typescript.
 - Using `@types` instead of typings.
-- Updated unit tests with updated `fetch-mock` package. 
+- Updated unit tests with updated `fetch-mock` package.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-patron-web",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "patron UI for Circulation Manager",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a draft PR to begin a discussion before I put in the work to do this. Ignore the changes, the `remove-server` branch is based on my `beta` branch, I haven't changed anything else in there yet.

### Reasons to remove the server
Right now the app is server-rendered, and I think there are a few compelling reasons to remove that functionality:

1. **Smaller codebase:** In general, minimizing the surface area of the code is an important goal for a project like this. Keeping the codebase simple will make it possible for a distributed team of engineers to maintain and improve it, especially when there are contractors coming and going. Removing the server would cut out a significant amount of error-prone code.
1. **Little added value:** Generally, server-rendering a react app is a performance optimization. In this case, it doesn't fetch all the required resources on the server, so it just shows the user a loading screen marginally faster. 
1. **Simpler deployments**: Right now we have to maintain a server for each CPW deployment. Both the code for that has to be maintained, and the devops takes work too. Without a server, we can simply deploy static files, which is far easier, faster, and less buggy.

### My proposal
I suggest we transition to codebase to use create-react-app. We would both remove the server, and most of the build configuration in favor of the more standard create-react-app config. It will allow us to do everything we need to do, but make the codebase much simpler and easier for new devs to become productive in. We would also benefit from the work the react team puts in to CRA, and would be able to upgrade seamlessly when they release new versions. The downside of this is we lose the ability to have custom configuration (unless we eject from CRA) - though I don't think we are doing anything currently that couldn't be done with a CRA-based project.

There are two alternative routes we could explore, however:
1. [Next.js](https://nextjs.org/): This is a framework for server-rendered react apps. I've used it many times, and it's quite good. The Zeit team does a great job maintaining it. If we wanted to keep the server rendering, this would be a really good choice. It also allows more configuration than CRA. While it would be significantly less complicated than our current setup, it's still slightly more than a CRA setup. It is also pretty proven tech, used by [many successful companies](https://nextjs.org/showcase) including Netflix, Hulu, Ticketmaster, etc. 
1. [Gatsby](https://www.gatsbyjs.org/docs/): This is a framework for (mostly) statically built websites, which our app falls into. I've used this many times as well, and it's fantastic. The basic premise is that it renders every page to a static html file at build time, which can then be served as static files. So it's actually faster than a server-rendered app, without the added devops complexity of deploying a server. The only pages that wouldn't be statically rendered are the dynamic ones (like the my-books page). It also has a really strong plugin system to enable any number of things from analytics to progressive-web-app functionality. The downside is that it would require a bit of extra work to connect the CM api to gatsby's graphql-based data layer, though once it's done, the dev experience is phenomenal.

### Questions
Am I missing something RE why the app was server rendered in the first place? James English mentioned that @aslagle might have chosen to server-render for security reasons? 

Let me know what you all think about this. I think moving to CRA or Next.js wouldn't be too much work and would help the app out a ton. Just want to make sure I hear your thoughts first.