### PR TITLE
CI/CD via github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+# For all PRs, this workflow will
+#     - Install deps
+#     - Lint
+#     - Typecheck
+#     - Test
+name: CI
+
+on:
+  # will run on all PRs that are opened or updated (synchronized)
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 13.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13.x
+      - name: Cache and install node modules
+        uses: bahmutov/npm-install@v1
+      - name: Lint
+        run: npm run lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 13.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13.x
+      - name: Cache and install node modules
+        uses: bahmutov/npm-install@v1
+      - name: Typecheck
+        run: tsc --noEmit
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 13.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13.x
+      - name: Cache and install node modules
+        uses: bahmutov/npm-install@v1
+      - name: Test
+        run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: tsc --noEmit
 
   test:
-    name: Test
+    name: Test & Coverage
     runs-on: ubuntu-latest
     env:
       CI: true
@@ -57,4 +57,8 @@ jobs:
       - name: Cache and install node modules
         uses: bahmutov/npm-install@v1
       - name: Test
-        run: npm run test
+        run: npm run test -- --coverage
+      - name: Coveralls Report
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -26,6 +26,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: nypl/patron-web
-          # tag the iamge with both beta and beta.short_sha
+          # tag the image with both beta and beta.short_sha
           tags: beta, beta.${{ steps.get_sha.outputs.short_sha }}
           add_git_labels: true

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,0 +1,31 @@
+# This workflow will publish the beta image to docker hub
+name: Publish beta
+
+# action will only run when a pull request to the beta branch is closed.
+on:
+  pull_request:
+    branches: [beta]
+    types: [closed]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  publish_beta:
+    name: Publish beta image to Docker Hub
+    # only run if the PR is merged.
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get short SHA
+        id: get_sha
+        run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+      - name: Publish to Docker Hub
+        id: publish_docker_hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: nypl/patron-web
+          # tag the iamge with both beta and beta.short_sha
+          tags: beta, beta.${{ steps.get_sha.outputs.short_sha }}
+          add_git_labels: true

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -1,0 +1,49 @@
+# This workflow will tag and release the master branch
+name: Production Release
+
+# workflow will only run when a pull request to the master branch is closed.
+on:
+  pull_request:
+    branches: [master]
+    types: [closed]
+
+jobs:
+  release_master:
+    name: Tag, Release and Publish master
+    # only run if PR is merged (not just closed)
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        # the tag will match the package.json version (eg. v1.0.0)
+      - name: Tag
+        id: autotagger
+        uses: butlerlogic/action-autotag@stable
+        with:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          strategy: package
+          prefix: v
+          # use the body of the PR commit as the tag message
+          tag_message: ${{ github.event.pull_request.body }}
+      - name: Release
+        id: create_release
+        if: steps.autotagger.outputs.tagname != ''
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.autotagger.outputs.tagname }}
+          release_name: ${{ steps.autotagger.outputs.tagname }}
+          # use the body of the PR commit as the release body
+          body: ${{ github.event.pull_request.body }}
+          draft: false
+          prerelease: false
+
+      - name: Publish to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: nypl/patron-web
+          tags: ${{steps.autotagger.outputs.version}}, latest
+          add_git_labels: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+### 2.0.1
+
+#### Added
+
+- Created Github Actions workflows to test, release, and deploy docker images to Docker Hub for beta and master.
+
 ### 2.0.0
 
 #### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # circulation-patron-web
 
+![Docker Image Version (latest semver)](https://img.shields.io/docker/v/nypl/patron-web?label=Docker%20Hub&logo=docker&sort=semver&style=flat)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/NYPL-Simplified/circulation-patron-web/CI?label=Tests&logo=github&style=flat)
+
 A Circulation catalog web interface for library patrons.
 
 ## Background
@@ -77,6 +80,13 @@ The following environment variables can also be set to further configure the app
 - `npm run lint:ts:fix` - Will lint the ts and tsx files and apply automatic fixes where possible.
 - `npm run generate-icons` - You can place svg files in `src/icons` and then run this command, and it will generate react components that can be imported and rendered normally.
 
+## Contributing
+
+There are two protected branches in this repository: `beta`, and `master`.
+
+- `master` is the most current production deployment code. Any time a PR is merged in to master, a release is tagged and created. A Docker Image is then built by Github Actions, which is finally pushed to Docker Hub with the tag `latest` as well as the specific version tag of the release (ie `2.3.6`). Generally, we only make PRs to `master` from `beta` unless a hotfix is necessary in production.
+- `beta` is the development and qa branch where feature PRs are brought together and staged/tried before being pushed into production. This is the default branch that most PRs should be pointed to. It is also tested, built and deployed by Github Actions with the tag `beta` and `beta.short_sha` where `short_sha` is from the most recent commit to beta. This way users can install the most recent beta using `beta` tag, or one at a specific commit for testing purposes.
+
 ## Testing
 
 The code is tested using Jest as a test runner and mocking library, and a combination of [React Testing Library](https://testing-library.com/docs/react-testing-library/intro) and [Enzyme](https://enzymejs.github.io/enzyme/). New tests are generally written with React Testing Library while the legacy tests were written with Enzyme. React Testing Library is good because it encourages devs not to test implementation details, but instead test the expected user experience. This results in tests that provide more confidence and change less frequently (they are implementation agnostic), therefore requiring less maintenance. In general, we have favored integration over unit tests, and testing components higher up the tree instead of in complete isolation. Similarly we have chosen to mock as few values and modules as possible. Both of these decisions will lead to higher confidence that the app works as expected for users.
@@ -147,7 +157,7 @@ test("fetches search description", async () => {
 
 ## Deploying
 
-This repository includes a Dockerfile, and the master branch is built as an image in Docker Hub in the Hub repository [nypl/patron-web](https://hub.docker.com/r/nypl/patron-web). You can deploy the application simply by running the image from Docker Hub.
+This repository includes a Dockerfile, and the master branch is built as an image in Docker Hub in the Hub repository [nypl/patron-web](https://hub.docker.com/r/nypl/patron-web). You can deploy the application simply by running the image from Docker Hub. You can either use the `latest` tag in Docker Hub, or a specific version tagged with the version number. There will also be an image tagged `beta` for the most recent code on the `beta` branch.
 
 Alternatively, you can build your own container from local changes as described below. If you would like to deploy from Docker Hub, skip to [Running a container from the image](#running-a-container-from-the-image).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-patron-web",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-patron-web",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "patron UI for Circulation Manager",
   "repository": {
     "type": "git",


### PR DESCRIPTION
These workflow files will implement the CI/CD steps we discussed in our phone call. I think having the docker image building live in github makes more sense than having it live in Docker Hub, because it allows us to see what is going on with that right here in github. And since I was building the image and creating the release here, I figured might as well add the CI checks too, so everything is in one place / through one service.

Specifics...

### PRs
This will run a series of checks on all PRs. We will want to set up the repository so that PRs go to the development (beta) branch by default, and that both master and beta are protected from direct commits/pushes. The checks this runs on PR:
1. Lint
2. Typecheck
3. Run tests

### Beta branch
When a PR is merged into the beta branch, this will build a new docker image and push it to Docker Hub with the tags `beta` and `beta.short_sha` where short_sha is a reference to the merge commit into beta (like `beta.baa1ca5`). So people using the image can always install the most recent beta with the tag `beta` or a specific beta by using the `beta.short_sha`.

We can name the development branch `dev` or something other than `beta` if you like. 

### Master branch
When a PR is merged into the master branch, this will 
1. Create a new tag using the `package.json` version number.
2. Create a new release for that tag
3. Build the image and push it to Docker Hub with the tags `latest` and `2.10` or whatever the version number is.

The tag message and the release body will be the body of the pull request merge commit. This way we can discuss a release in a PR, come up with the release notes, then merge the PR with the release notes in the PR body. 

### Other things we can set up for the future
1. Slack notifications of releases or new beta builds (and failures)
1. Comment the published docker image on the PR for reference.
2. Automatic version number changes via PR label. One label of `major`, `minor`, `patch` or `no-version-change` would be required as a check on the PR.
3. Require that the changelog is updated as a PR check.

Once we merge this I will add docker secrets to the repo that will give push permission to `nypl/patron-web`, and we will have to configure the branch protections.