### PR TITLE
remove travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-
-node_js:
-  - "13"
-
-git:
-  submodules: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+## 2.0.2
+
+- Removed travis CI as it has been replaced by Github Actions
+
 ### 2.0.1
 
 #### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-patron-web",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-patron-web",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "patron UI for Circulation Manager",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The travis CI workflow is redundant now that we have the github actions version, so this removes it.