### PR TITLE
no audiobook downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: Only show download options for open-access books once they have been borrowed and are present in a user's loans. Download options should still be shown for open-access books in libraries that do not have any auth enabled.
 - Fix: Don't perform state update on unmounted `BorrowCard`. 
 - Refactor: Rename `node` in tests to `utils`, as it is more accurate.
+- Fix: Don't show download options for audiobooks since there is no way to play them on desktop. Only show SimplyE callout instead.
 
 ## 2.2.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3237,9 +3237,9 @@
       }
     },
     "@nypl/dgx-svg-icons": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.9.tgz",
-      "integrity": "sha512-y4cgTHunDgBAhKon/ukkKdlTlS4Xpo7sRUGbsLpbbjsc6stcxAU8Kkjde5ycxOaR4jVNCG65kLEiQGZycZ+fPw=="
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.12.tgz",
+      "integrity": "sha512-Co92hdOAL04STAKLa2JFQPdo/As3NDDVsPf1aiAfMPLzMKr4T8914V+0fMmLRZ7QL9xVOuCWU2vgo4pUgE0DxA=="
     },
     "@popperjs/core": {
       "version": "2.4.0",
@@ -6633,11 +6633,11 @@
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "^0.6.2"
       }
     },
     "end-of-stream": {
@@ -8444,11 +8444,11 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "icss-utils": {
@@ -12819,9 +12819,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.4.2.tgz",
-      "integrity": "sha512-vnjHeBPoRTexPR43+MhLUc17shvxIPRUC26o6YI6DxmpMEiD8q1c1tDNUJXFdA2/m+cdS+yciIAr3DOF3Wv8SQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.4.4.tgz",
+      "integrity": "sha512-lLpK1W+Jh86qF/s+i5TTs0KPP3x2Icg0br23NBi+oAh1YnxKcvgV/7dmfqDUxL8w1sDzWgiaGqKMOz+qMN+/pA==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "moment": "^2.24.0",
     "next": "^9.4.2",
     "opds-feed-parser": "0.0.18",
-    "opds-web-client": "^0.4.2",
+    "opds-web-client": "^0.4.4",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-hook-form": "^4.9.2",

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -5,7 +5,8 @@ import {
   getFulfillmentState,
   dedupeLinks,
   availabilityString,
-  queueString
+  queueString,
+  bookIsAudiobook
 } from "utils/book";
 import {
   BookData,
@@ -236,6 +237,7 @@ const DownloadCard: React.FC<{
 }> = ({ book, links, subtitle, isOpenAccess = false }) => {
   const { title } = book;
   const dedupedLinks = dedupeLinks(links ?? []);
+  const isAudiobook = bookIsAudiobook(book);
 
   return (
     <>
@@ -248,29 +250,31 @@ const DownloadCard: React.FC<{
           <Text>{subtitle}</Text>
         </Stack>
       </Stack>
-      <Stack direction="column" sx={{ mt: 3 }}>
-        <Text variant="text.body.italic" sx={{ textAlign: "center" }}>
-          If you would rather read on your computer, you can:
-        </Text>
-        <Stack sx={{ justifyContent: "center", flexWrap: "wrap" }}>
-          {dedupedLinks.map(link =>
-            isOpenAccess ? (
-              <AnchorButton
-                key={link.url}
-                variant="ghost"
-                color="ui.gray.extraDark"
-                newTab
-                href={link.url}
-              >
-                <SvgDownload sx={{ mr: 1 }} /> Download{" "}
-                {typeMap[link.type].name}
-              </AnchorButton>
-            ) : (
-              <DownloadButton key={link.url} link={link} title={title} />
-            )
-          )}
+      {!isAudiobook && (
+        <Stack direction="column" sx={{ mt: 3 }}>
+          <Text variant="text.body.italic" sx={{ textAlign: "center" }}>
+            If you would rather read on your computer, you can:
+          </Text>
+          <Stack sx={{ justifyContent: "center", flexWrap: "wrap" }}>
+            {dedupedLinks.map(link =>
+              isOpenAccess ? (
+                <AnchorButton
+                  key={link.url}
+                  variant="ghost"
+                  color="ui.gray.extraDark"
+                  newTab
+                  href={link.url}
+                >
+                  <SvgDownload sx={{ mr: 1 }} /> Download{" "}
+                  {typeMap[link.type].name}
+                </AnchorButton>
+              ) : (
+                <DownloadButton key={link.url} link={link} title={title} />
+              )
+            )}
+          </Stack>
         </Stack>
-      </Stack>
+      )}
     </>
   );
 };

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -452,4 +452,24 @@ describe("available to download", () => {
       "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media"
     );
   });
+
+  test("does not show download links for audiobooks", () => {
+    const audiobook = mergeBook({
+      raw: {
+        $: {
+          "schema:additionalType": {
+            value: "http://bib.schema.org/Audiobook"
+          }
+        }
+      }
+    });
+
+    const utils = render(<FulfillmentCard book={audiobook} />);
+
+    expect(
+      utils.queryByText("If you would rather read on your computer, you can:")
+    ).toBeNull();
+
+    expect(utils.queryByText(/Download/i)).toBeNull();
+  });
 });

--- a/src/utils/__tests__/book.test.ts
+++ b/src/utils/__tests__/book.test.ts
@@ -180,8 +180,8 @@ describe("getFulfillmentState", () => {
           ...bookFixture,
           openAccessLinks: undefined,
           fulfillmentLinks: undefined,
-          availability: { status: "" },
-          borrowUrl: "/borrow"
+          availability: { status: "available" },
+          borrowUrl: undefined
         },
         false
       )

--- a/src/utils/book.tsx
+++ b/src/utils/book.tsx
@@ -8,6 +8,7 @@ import {
 import { BookFulfillmentState } from "interfaces";
 
 import { Book, Headset } from "../icons";
+import { getMedium } from "opds-web-client/lib/utils/book";
 
 export function getAuthors(book: BookData, lim?: number): string[] {
   // select contributors if the authors array is undefined or empty.
@@ -105,6 +106,13 @@ export function getErrorMsg(error: FetchErrorData | null): string | null {
     }
   }
   return null;
+}
+
+export function bookIsAudiobook(book: BookData): boolean {
+  if (getMedium(book) === "http://bib.schema.org/Audiobook") {
+    return true;
+  }
+  return false;
 }
 
 export const bookMediumMap: {


### PR DESCRIPTION
This PR removes download options for audiobooks since they cannot be played outside of SimplyE. Instead, we only show the "You are now ready to read this book in SimplyE!" banner.