### PR TITLE
replace node with utils in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix: Only show download options for open-access books once they have been borrowed and are present in a user's loans. Download options should still be shown for open-access books in libraries that do not have any auth enabled.
 - Fix: Don't perform state update on unmounted `BorrowCard`. 
+- Refactor: Rename `node` in tests to `utils`, as it is more accurate.
 
 ## 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -154,20 +154,20 @@ test("fetches search description", async () => {
     "fetchSearchDescription"
   );
   /**
-   * node will contain
+   * utils will contain
    *  - the result of render
    *  - the redux store
    *  - the history object
    *  - the spied on dispatch function
    */
-  const node = render(<Search />, {
+  const utils = render(<Search />, {
     initialState
   });
 
   expect(mockedFetchSearchDescription).toHaveBeenCalledTimes(1);
   expect(mockedFetchSearchDescription).toHaveBeenCalledWith("/search-url");
   // we can assert on the app's dispatch like this
-  expect(node.dispatch).toHaveBeenCalledTimes(1);
+  expect(utils.dispatch).toHaveBeenCalledTimes(1);
 });
 ```
 

--- a/src/components/__tests__/Auth.test.tsx
+++ b/src/components/__tests__/Auth.test.tsx
@@ -23,7 +23,7 @@ test("shows overlay on unauthenticated request", async () => {
     body: merge({}, fixtures.server401Response)
   });
 
-  const node = render(
+  const utils = render(
     <Auth>
       <div>children</div>
     </Auth>,
@@ -32,7 +32,7 @@ test("shows overlay on unauthenticated request", async () => {
     }
   );
   // overlay should not be shown yet
-  const modal = node.getByLabelText("Sign In");
+  const modal = utils.getByLabelText("Sign In");
   expect(modal).toBeInTheDocument();
   expect(modal).toHaveStyle("display: none");
 
@@ -40,7 +40,7 @@ test("shows overlay on unauthenticated request", async () => {
    * we need to dispatch some action that makes a server request
    * and will receive our mocked 401
    */
-  node.dispatch(actions.fetchCollection("/some-collection"));
+  utils.dispatch(actions.fetchCollection("/some-collection"));
   // now see that the overlay is shown.
   await waitFor(() => expect(modal).toHaveStyle("display: block"));
 });
@@ -60,7 +60,7 @@ const stateWithShowForm: State = merge<State>(fixtures.initialState, {
 });
 
 test("shows overlay when showForm is true", async () => {
-  const node = render(
+  const utils = render(
     <Auth>
       <div>children</div>
     </Auth>,
@@ -69,13 +69,13 @@ test("shows overlay when showForm is true", async () => {
     }
   );
   // overlay should be shown
-  const modal = node.getByLabelText("Sign In");
+  const modal = utils.getByLabelText("Sign In");
   expect(modal).toBeInTheDocument();
   expect(modal).toHaveStyle("display: block");
 });
 
 test("renders auth form provided in authPlugin", async () => {
-  const node = render(
+  const utils = render(
     <Auth>
       <div>children</div>
     </Auth>,
@@ -84,11 +84,11 @@ test("renders auth form provided in authPlugin", async () => {
     }
   );
   // overlay should be shown
-  const modal = node.getByLabelText("Sign In");
+  const modal = utils.getByLabelText("Sign In");
   expect(modal).toBeInTheDocument();
   expect(modal).toHaveStyle("display: block");
   // should include the BasicAuthForm
-  expect(node.getByLabelText("Pin")).toBeInTheDocument();
+  expect(utils.getByLabelText("Pin")).toBeInTheDocument();
 });
 
 test("displays message when no auth provider configured", async () => {
@@ -111,7 +111,7 @@ test("displays message when no auth provider configured", async () => {
       arrayMerge: (a, b) => b
     }
   );
-  const node = render(
+  const utils = render(
     <Auth>
       <div>children</div>
     </Auth>,
@@ -120,11 +120,13 @@ test("displays message when no auth provider configured", async () => {
     }
   );
   // overlay should be shown
-  const modal = node.getByLabelText("Sign In");
+  const modal = utils.getByLabelText("Sign In");
   expect(modal).toBeInTheDocument();
   expect(modal).toHaveStyle("display: block");
 
-  expect(node.getByText("Basic auth provider is missing.")).toBeInTheDocument();
+  expect(
+    utils.getByText("Basic auth provider is missing.")
+  ).toBeInTheDocument();
 });
 
 test("attempts to get credentials from cookies", async () => {

--- a/src/components/__tests__/BasicAuthForm.test.tsx
+++ b/src/components/__tests__/BasicAuthForm.test.tsx
@@ -43,17 +43,17 @@ const authState: AuthState = {
 };
 
 test("displays form", () => {
-  const node = render(<BasicAuthForm provider={provider} />, {
+  const utils = render(<BasicAuthForm provider={provider} />, {
     initialState: merge<State>(fixtures.initialState, {
       auth: authState
     })
   });
-  expect(node.getByLabelText("Barcode")).toBeInTheDocument();
-  expect(node.getByLabelText("Pin")).toBeInTheDocument();
-  expect(node.getByText("Login")).toBeInTheDocument();
+  expect(utils.getByLabelText("Barcode")).toBeInTheDocument();
+  expect(utils.getByLabelText("Pin")).toBeInTheDocument();
+  expect(utils.getByText("Login")).toBeInTheDocument();
 
-  const barcode = node.getByLabelText("Barcode");
-  const pin = node.getByLabelText("Pin");
+  const barcode = utils.getByLabelText("Barcode");
+  const pin = utils.getByLabelText("Pin");
   userEvent.type(barcode, "1234");
   userEvent.type(pin, "pinpin");
 
@@ -71,25 +71,25 @@ const mockedGenerateCredentials = jest
 test("sumbits", async () => {
   const mockSaveAuthCredentials = jest.spyOn(actions, "saveAuthCredentials");
 
-  const node = render(<BasicAuthForm provider={provider} />, {
+  const utils = render(<BasicAuthForm provider={provider} />, {
     initialState: merge<State>(fixtures.initialState, {
       auth: authState
     })
   });
 
   // act
-  const barcode = node.getByLabelText("Barcode");
-  const pin = node.getByLabelText("Pin");
+  const barcode = utils.getByLabelText("Barcode");
+  const pin = utils.getByLabelText("Pin");
   userEvent.type(barcode, "1234");
   userEvent.type(pin, "pinpin");
-  const loginButton = node.getByText("Login");
+  const loginButton = utils.getByText("Login");
   userEvent.click(loginButton);
 
   // assert
   // we wrap this in waitFor because the handleSubmit from react-hook-form has
   // async code in it
   await waitFor(() => {
-    expect(node.dispatch).toHaveBeenCalledTimes(1);
+    expect(utils.dispatch).toHaveBeenCalledTimes(1);
     expect(mockedGenerateCredentials).toHaveBeenCalledTimes(1);
     expect(mockedGenerateCredentials).toHaveBeenCalledWith("1234", "pinpin");
     expect(mockSaveAuthCredentials).toHaveBeenCalledWith({
@@ -101,20 +101,20 @@ test("sumbits", async () => {
 });
 
 test("displays client error when unfilled", async () => {
-  const node = render(<BasicAuthForm provider={provider} />, {
+  const utils = render(<BasicAuthForm provider={provider} />, {
     initialState: merge<State>(fixtures.initialState, {
       auth: authState
     })
   });
 
   // don't fill form, but click login
-  const loginButton = node.getByText("Login");
+  const loginButton = utils.getByText("Login");
   userEvent.click(loginButton);
 
   // assert
-  await node.findByText("Your Barcode is required.");
-  await node.findByText("Your Pin is required.");
-  expect(node.dispatch).toHaveBeenCalledTimes(0);
+  await utils.findByText("Your Barcode is required.");
+  await utils.findByText("Your Pin is required.");
+  expect(utils.dispatch).toHaveBeenCalledTimes(0);
   expect(mockedGenerateCredentials).toHaveBeenCalledTimes(0);
   expect(authCallback).toHaveBeenCalledTimes(0);
 });
@@ -133,13 +133,13 @@ const authStateWithError: AuthState = {
   providers: [provider]
 };
 test("displays server error", async () => {
-  const node = render(<BasicAuthForm provider={provider} />, {
+  const utils = render(<BasicAuthForm provider={provider} />, {
     initialState: merge<State>(fixtures.initialState, {
       auth: authStateWithError
     })
   });
 
-  const serverError = node.getByText("Error: Server error string");
+  const serverError = utils.getByText("Error: Server error string");
   expect(serverError).toBeInTheDocument();
 });
 
@@ -177,11 +177,11 @@ test("accepts different input labels", async () => {
   const stateWithLabels = merge<State>(fixtures.initialState, {
     auth: authStateWithLabel
   });
-  const node = render(<BasicAuthForm provider={providerWithLabel} />, {
+  const utils = render(<BasicAuthForm provider={providerWithLabel} />, {
     initialState: stateWithLabels
   });
 
-  expect(node.getByLabelText("Username")).toBeInTheDocument();
-  expect(node.getByLabelText("Password")).toBeInTheDocument();
-  expect(node.getByText("Login")).toBeInTheDocument();
+  expect(utils.getByLabelText("Username")).toBeInTheDocument();
+  expect(utils.getByLabelText("Password")).toBeInTheDocument();
+  expect(utils.getByText("Login")).toBeInTheDocument();
 });

--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -52,7 +52,7 @@ describe("available to borrow book", () => {
       );
     // also spy on fetchLoans
     const fetchLoansSpy = jest.spyOn(actions, "fetchLoans");
-    const node = render(<BookListItem book={closedAccessBook} />, {
+    const utils = render(<BookListItem book={closedAccessBook} />, {
       initialState: merge<State>(fixtures.initialState, {
         loans: {
           url: "/loans-url",
@@ -61,10 +61,10 @@ describe("available to borrow book", () => {
       })
     });
     // click borrow
-    userEvent.click(node.getByText("Borrow"));
+    userEvent.click(utils.getByText("Borrow"));
     expect(updateBookSpy).toHaveBeenCalledTimes(1);
     expect(updateBookSpy).toHaveBeenCalledWith("borrow url");
-    const borrowButton = await node.findByRole("button", {
+    const borrowButton = await utils.findByRole("button", {
       name: "Borrowing..."
     });
     expect(borrowButton).toBeInTheDocument();
@@ -79,7 +79,7 @@ describe("available to borrow book", () => {
       status: 403,
       url: "error-url"
     };
-    const node = render(<BookListItem book={closedAccessBook} />, {
+    const utils = render(<BookListItem book={closedAccessBook} />, {
       initialState: merge(fixtures.initialState, {
         book: {
           error: err
@@ -87,10 +87,10 @@ describe("available to borrow book", () => {
       })
     });
     expect(
-      node.queryByText("10 out of 13 copies available.")
+      utils.queryByText("10 out of 13 copies available.")
     ).not.toBeInTheDocument();
     expect(
-      node.getByText("Error: cannot loan more than 3 documents.")
+      utils.getByText("Error: cannot loan more than 3 documents.")
     ).toBeInTheDocument();
   });
 });
@@ -126,7 +126,7 @@ describe("ready to borrow book", () => {
       );
     // also spy on fetchLoans
     const fetchLoansSpy = jest.spyOn(actions, "fetchLoans");
-    const node = render(<BookListItem book={readyBook} />, {
+    const utils = render(<BookListItem book={readyBook} />, {
       initialState: merge<State>(fixtures.initialState, {
         loans: {
           url: "/loans-url",
@@ -135,10 +135,10 @@ describe("ready to borrow book", () => {
       })
     });
     // click borrow
-    userEvent.click(node.getByText("Borrow"));
+    userEvent.click(utils.getByText("Borrow"));
     expect(updateBookSpy).toHaveBeenCalledTimes(1);
     expect(updateBookSpy).toHaveBeenCalledWith("borrow url");
-    const borrowButton = await node.findByRole("button", {
+    const borrowButton = await utils.findByRole("button", {
       name: "Borrowing..."
     });
     expect(borrowButton).toBeInTheDocument();
@@ -153,7 +153,7 @@ describe("ready to borrow book", () => {
       status: 403,
       url: "error-url"
     };
-    const node = render(<BookListItem book={readyBook} />, {
+    const utils = render(<BookListItem book={readyBook} />, {
       initialState: merge(fixtures.initialState, {
         book: {
           error: err
@@ -161,10 +161,10 @@ describe("ready to borrow book", () => {
       })
     });
     expect(
-      node.queryByText("You can now borrow this book!")
+      utils.queryByText("You can now borrow this book!")
     ).not.toBeInTheDocument();
     expect(
-      node.getByText("Error: cannot loan more than 3 documents.")
+      utils.getByText("Error: cannot loan more than 3 documents.")
     ).toBeInTheDocument();
   });
 });
@@ -182,14 +182,16 @@ describe("available to reserve book", () => {
   });
 
   test("displays correct title and subtitle", () => {
-    const node = render(<BookListItem book={unavailableBook} />);
-    expect(node.getByText("0 out of 13 copies available.")).toBeInTheDocument();
-    expectViewDetails(node);
+    const utils = render(<BookListItem book={unavailableBook} />);
+    expect(
+      utils.getByText("0 out of 13 copies available.")
+    ).toBeInTheDocument();
+    expectViewDetails(utils);
   });
 
   test("displays reserve button", () => {
-    const node = render(<BookListItem book={unavailableBook} />);
-    const reserveButton = node.getByRole("button", { name: "Reserve" });
+    const utils = render(<BookListItem book={unavailableBook} />);
+    const reserveButton = utils.getByRole("button", { name: "Reserve" });
     expect(reserveButton).toBeInTheDocument();
   });
 
@@ -206,7 +208,7 @@ describe("available to reserve book", () => {
       );
     // also spy on fetchLoans
     const fetchLoansSpy = jest.spyOn(actions, "fetchLoans");
-    const node = render(<BookListItem book={unavailableBook} />, {
+    const utils = render(<BookListItem book={unavailableBook} />, {
       initialState: merge<State>(fixtures.initialState, {
         loans: {
           url: "/loans-url",
@@ -215,10 +217,10 @@ describe("available to reserve book", () => {
       })
     });
     // click reserve
-    userEvent.click(node.getByText("Reserve"));
+    userEvent.click(utils.getByText("Reserve"));
     expect(updateBookSpy).toHaveBeenCalledTimes(1);
     expect(updateBookSpy).toHaveBeenCalledWith("borrow url");
-    const reserveButton = await node.findByRole("button", {
+    const reserveButton = await utils.findByRole("button", {
       name: "Reserving..."
     });
     expect(reserveButton).toBeInTheDocument();
@@ -241,12 +243,12 @@ describe("reserved book", () => {
   });
 
   test("displays disabled reserve button and text", () => {
-    const node = render(<BookListItem book={reservedBook} />);
-    const reserveButton = node.getByText("Reserved");
+    const utils = render(<BookListItem book={reservedBook} />);
+    const reserveButton = utils.getByText("Reserved");
     expect(reserveButton).toBeInTheDocument();
     expect(reserveButton).toBeDisabled();
 
-    expect(node.getByText("You have this book on hold.")).toBeInTheDocument();
+    expect(utils.getByText("You have this book on hold.")).toBeInTheDocument();
   });
 
   test("displays number of patrons in queue and your position", () => {
@@ -264,9 +266,9 @@ describe("reserved book", () => {
         position: 5
       }
     });
-    const node = render(<BookListItem book={reservedBookWithQueue} />);
+    const utils = render(<BookListItem book={reservedBookWithQueue} />);
     expect(
-      node.getByText("You have this book on hold. Position: 5")
+      utils.getByText("You have this book on hold. Position: 5")
     ).toBeInTheDocument();
   });
 });
@@ -293,11 +295,11 @@ describe("available to access book", () => {
   });
 
   test("displays correct title and subtitle and view details", () => {
-    const node = render(<BookListItem book={downloadableBook} />);
+    const utils = render(<BookListItem book={downloadableBook} />);
     expect(
-      node.getByText("You have this book on loan until Thu Jun 18 2020.")
+      utils.getByText("You have this book on loan until Thu Jun 18 2020.")
     ).toBeInTheDocument();
-    expectViewDetails(node);
+    expectViewDetails(utils);
   });
 
   test("handles lack of availability info", () => {
@@ -305,7 +307,7 @@ describe("available to access book", () => {
       ...downloadableBook,
       availability: undefined
     });
-    const node = render(<BookListItem book={withoutAvailability} />);
-    expect(node.getByText("You have this book on loan.")).toBeInTheDocument();
+    const utils = render(<BookListItem book={withoutAvailability} />);
+    expect(utils.getByText("You have this book on loan.")).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/BreadcrumbBar.test.tsx
+++ b/src/components/__tests__/BreadcrumbBar.test.tsx
@@ -55,45 +55,45 @@ test("shows clicklable breadcrumbs", () => {
   // which would leak across tests
   mockedComputeBreadcrumbs.mockReturnValueOnce([...breadcrumbs]);
 
-  const node = render(<BreadcrumbBar />, {
+  const utils = render(<BreadcrumbBar />, {
     initialState: stateWithCrumbs
   });
 
-  const allBooks = node.getByText("All Books");
+  const allBooks = utils.getByText("All Books");
   expect(allBooks.closest("a")).toHaveAttribute(
     "href",
     "/collection/url-allbooks"
   );
 
-  const libraryCrumb = node.getByText("lib");
+  const libraryCrumb = utils.getByText("lib");
   expect(libraryCrumb.closest("a")).toHaveAttribute(
     "href",
     "/collection/url-lib"
   );
 
   // the last item isn't a link
-  const lastItem = node.getByText("Last Item");
+  const lastItem = utils.getByText("Last Item");
   expect(lastItem.closest("a")).toBeNull();
 });
 
 test("adds current location", () => {
   mockedComputeBreadcrumbs.mockReturnValueOnce([...breadcrumbs]);
 
-  const node = render(<BreadcrumbBar currentLocation="We are here" />, {
+  const utils = render(<BreadcrumbBar currentLocation="We are here" />, {
     initialState: stateWithCrumbs
   });
 
-  const lastItem = node.getByText("Last Item");
+  const lastItem = utils.getByText("Last Item");
   expect(lastItem.closest("a")).toHaveAttribute("href", "/collection/last-url");
 
-  const currentLoc = node.getByText("We are here");
+  const currentLoc = utils.getByText("We are here");
   expect(currentLoc.closest("a")).toBeNull();
 });
 
 test("renders children", () => {
   mockedComputeBreadcrumbs.mockReturnValueOnce([...breadcrumbs]);
 
-  const node = render(
+  const utils = render(
     <BreadcrumbBar>
       <div>Hi Im here</div>
     </BreadcrumbBar>,
@@ -101,5 +101,5 @@ test("renders children", () => {
       initialState: stateWithCrumbs
     }
   );
-  expect(node.getByText("Hi Im here")).toBeInTheDocument();
+  expect(utils.getByText("Hi Im here")).toBeInTheDocument();
 });

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -4,32 +4,32 @@ import Button, { NavButton, AnchorButton } from "../Button";
 
 describe("variants", () => {
   test("filled (default)", () => {
-    const node = render(<Button>child</Button>);
-    const button = node.getByText("child");
+    const utils = render(<Button>child</Button>);
+    const button = utils.getByText("child");
     expect(button).toMatchSnapshot();
   });
   test("ghost", () => {
-    const node = render(<Button variant="ghost">child</Button>);
-    const button = node.getByText("child");
+    const utils = render(<Button variant="ghost">child</Button>);
+    const button = utils.getByText("child");
     expect(button).toMatchSnapshot();
   });
   test("link", () => {
-    const node = render(<Button variant="link">child</Button>);
-    const button = node.getByText("child");
+    const utils = render(<Button variant="link">child</Button>);
+    const button = utils.getByText("child");
     expect(button).toMatchSnapshot();
   });
 });
 test("NavButton renders correct element", () => {
-  const node = render(<NavButton href="/somewhere">child</NavButton>);
-  const button = node.getByText("child");
+  const utils = render(<NavButton href="/somewhere">child</NavButton>);
+  const button = utils.getByText("child");
   expect(button).toHaveAttribute("href", "/somewhere");
   expect(button).toMatchSnapshot();
 });
 test("LinkButton renders correct element", () => {
-  const node = render(
+  const utils = render(
     <AnchorButton href="http://some.com/external">child</AnchorButton>
   );
-  const button = node.getByText("child");
+  const button = utils.getByText("child");
   expect(button).toHaveAttribute("href", "http://some.com/external");
   expect(button).toMatchSnapshot();
 });

--- a/src/components/__tests__/Collection.test.tsx
+++ b/src/components/__tests__/Collection.test.tsx
@@ -22,7 +22,7 @@ test("calls setCollectionAndBook", () => {
 });
 
 test("displays loader", () => {
-  const node = render(
+  const utils = render(
     <Collection setCollectionAndBook={setCollectionAndBook} />,
     {
       initialState: merge(fixtures.initialState, {
@@ -32,7 +32,9 @@ test("displays loader", () => {
       })
     }
   );
-  expect(node.getByRole("heading", { name: "Loading..." })).toBeInTheDocument();
+  expect(
+    utils.getByRole("heading", { name: "Loading..." })
+  ).toBeInTheDocument();
 });
 
 test("displays lanes when present", () => {
@@ -49,7 +51,7 @@ test("displays lanes when present", () => {
       }
     }
   });
-  const node = render(
+  const utils = render(
     <Collection setCollectionAndBook={setCollectionAndBook} />,
     {
       initialState
@@ -57,11 +59,11 @@ test("displays lanes when present", () => {
   );
 
   // expect there to be a lane with books
-  const laneTitle = node.getByText("my lane");
+  const laneTitle = utils.getByText("my lane");
   expect(laneTitle).toBeInTheDocument();
-  expect(node.getByText(fixtures.makeBook(0).title)).toBeInTheDocument();
+  expect(utils.getByText(fixtures.makeBook(0).title)).toBeInTheDocument();
   expect(
-    node.getByText(fixtures.makeBook(0).authors.join(", "))
+    utils.getByText(fixtures.makeBook(0).authors.join(", "))
   ).toBeInTheDocument();
 });
 
@@ -79,7 +81,7 @@ test("prefers lanes over books", () => {
       }
     }
   });
-  const node = render(
+  const utils = render(
     <Collection setCollectionAndBook={setCollectionAndBook} />,
     {
       initialState
@@ -88,7 +90,7 @@ test("prefers lanes over books", () => {
 
   // expect the lane title to be rendered, indicating it chose
   // lanes over books
-  const laneTitle = node.getByText("my lane");
+  const laneTitle = utils.getByText("my lane");
   expect(laneTitle).toBeInTheDocument();
 });
 
@@ -101,18 +103,18 @@ test("renders books in list view if no lanes", () => {
       }
     }
   });
-  const node = render(
+  const utils = render(
     <Collection setCollectionAndBook={setCollectionAndBook} />,
     {
       initialState
     }
   );
 
-  const list = node.getByTestId("listview-list");
+  const list = utils.getByTestId("listview-list");
   expect(list).toBeInTheDocument();
-  expect(node.getByText(fixtures.makeBook(0).title)).toBeInTheDocument();
+  expect(utils.getByText(fixtures.makeBook(0).title)).toBeInTheDocument();
   expect(
-    node.getByText(fixtures.makeBook(0).authors.join(", "))
+    utils.getByText(fixtures.makeBook(0).authors.join(", "))
   ).toBeInTheDocument();
 });
 
@@ -125,12 +127,12 @@ test("renders empty state if no lanes or books", () => {
       }
     }
   });
-  const node = render(
+  const utils = render(
     <Collection setCollectionAndBook={setCollectionAndBook} />,
     {
       initialState
     }
   );
 
-  expect(node.getByText("This collection is empty.")).toBeInTheDocument();
+  expect(utils.getByText("This collection is empty.")).toBeInTheDocument();
 });

--- a/src/components/__tests__/Error.test.tsx
+++ b/src/components/__tests__/Error.test.tsx
@@ -3,36 +3,36 @@ import { render } from "../../test-utils";
 import Error from "../Error";
 
 test("renders error message with 404 status code if status code not provided", () => {
-  const node = render(<Error />);
+  const utils = render(<Error />);
   expect(
-    node.getByText("Error: This page could not be found")
+    utils.getByText("Error: This page could not be found")
   ).toBeInTheDocument();
-  expect(node.getByText("A 404 error occurred on server")).toBeInTheDocument();
+  expect(utils.getByText("A 404 error occurred on server")).toBeInTheDocument();
 });
 
 test("renders 404 error message when there is a 404 error", () => {
-  const node = render(<Error statusCode={404} />);
+  const utils = render(<Error statusCode={404} />);
   expect(
-    node.getByText("Error: This page could not be found")
+    utils.getByText("Error: This page could not be found")
   ).toBeInTheDocument();
-  expect(node.getByText("A 404 error occurred on server")).toBeInTheDocument();
+  expect(utils.getByText("A 404 error occurred on server")).toBeInTheDocument();
 });
 
 test("renders error message with status code", () => {
-  const node = render(<Error statusCode={400} />);
-  expect(node.getByText("A 400 error occurred on server")).toBeInTheDocument();
+  const utils = render(<Error statusCode={400} />);
+  expect(utils.getByText("A 400 error occurred on server")).toBeInTheDocument();
 });
 
 test("renders error page with title", () => {
-  const node = render(<Error title={"No active hold"} />);
-  expect(node.getByText("Error: No active hold")).toBeInTheDocument();
+  const utils = render(<Error title={"No active hold"} />);
+  expect(utils.getByText("Error: No active hold")).toBeInTheDocument();
 });
 
 test("renders error page with detail", () => {
-  const node = render(
+  const utils = render(
     <Error detail={"All licenses for this book are loaned out."} />
   );
   expect(
-    node.getByText("All licenses for this book are loaned out.")
+    utils.getByText("All licenses for this book are loaned out.")
   ).toBeInTheDocument();
 });

--- a/src/components/__tests__/Lane.test.tsx
+++ b/src/components/__tests__/Lane.test.tsx
@@ -33,8 +33,8 @@ const laneData: LaneData = {
 };
 
 test("Renders", () => {
-  const node = render(<Lane lane={laneData} />);
-  const book1 = node.getByText("Book Title 1");
+  const utils = render(<Lane lane={laneData} />);
+  const book1 = utils.getByText("Book Title 1");
   expect(book1).toBeInTheDocument();
 });
 
@@ -43,32 +43,32 @@ test("renders breadcrumbs with 0 books", () => {
     ...laneData,
     books: []
   };
-  const node = render(<Lane lane={withNoBooks} />);
+  const utils = render(<Lane lane={withNoBooks} />);
 
   // it should just show the breadcrumb
-  const breadcrumb = node.getByText("my lane");
+  const breadcrumb = utils.getByText("my lane");
   expect(breadcrumb).toBeInTheDocument();
 
   // there should be no li elements
-  expect(node.getByTestId("lane-list")).toBeEmpty();
+  expect(utils.getByTestId("lane-list")).toBeEmpty();
 });
 
 test("filters books", () => {
-  const node = render(
+  const utils = render(
     <Lane lane={laneData} omitIds={["Book Id 1", "Book Id 2"]} />
   );
 
-  expect(node.queryByText("Book Title 1")).toBeNull();
-  expect(node.queryByText("Book Title 2")).toBeNull();
+  expect(utils.queryByText("Book Title 1")).toBeNull();
+  expect(utils.queryByText("Book Title 2")).toBeNull();
 
-  expect(node.getByText("Book Title 0")).toBeInTheDocument();
-  expect(node.getByText("Book Title 3")).toBeInTheDocument();
+  expect(utils.getByText("Book Title 0")).toBeInTheDocument();
+  expect(utils.getByText("Book Title 3")).toBeInTheDocument();
 });
 
 test("more button navigates to the right link", () => {
-  const node = render(<Lane lane={laneData} />);
+  const utils = render(<Lane lane={laneData} />);
 
-  const moreButton = node.getByText("See More").closest("a");
+  const moreButton = utils.getByText("See More").closest("a");
 
   expect(moreButton).toHaveAttribute("href", "/collection/link-to-lane");
 });

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -6,35 +6,37 @@ import userEvent from "@testing-library/user-event";
 
 describe("Layout nav + structure", () => {
   test("Library icon button navigates home", () => {
-    const node = render(<Layout>Child</Layout>);
-    const homeButton = node.getByLabelText("Library catalog, back to homepage");
+    const utils = render(<Layout>Child</Layout>);
+    const homeButton = utils.getByLabelText(
+      "Library catalog, back to homepage"
+    );
 
     // the home button should navigate to "/"
     expect(homeButton.closest("a")).toHaveAttribute("href", "/");
   });
 
   test("my books navigates to /loans", () => {
-    const node = render(<Layout>Child</Layout>, {
+    const utils = render(<Layout>Child</Layout>, {
       initialState: merge(fixtures.initialState, {
         loans: {
           url: "/myloans" // this url is not used for navigation, but for fetching loans
         }
       })
     });
-    const myBooks = node.getAllByRole("link", { name: "My Books" });
+    const myBooks = utils.getAllByRole("link", { name: "My Books" });
     myBooks.forEach(ln => expect(ln).toHaveAttribute("href", "/loans"));
   });
 
   test("displays children within main", () => {
-    const node = render(<Layout>Some children</Layout>);
-    const main = node.getByRole("main");
+    const utils = render(<Layout>Some children</Layout>);
+    const main = utils.getByRole("main");
     expect(main).toHaveTextContent("Some children");
   });
 
   test("provides a working skip nav link", async () => {
-    const node = render(<Layout>Child</Layout>);
-    const skipNav = node.getByText("Skip to content").closest("a");
-    const main = node.getByRole("main");
+    const utils = render(<Layout>Child</Layout>);
+    const skipNav = utils.getByText("Skip to content").closest("a");
+    const main = utils.getByRole("main");
 
     userEvent.tab();
     expect(skipNav).toHaveFocus();

--- a/src/components/__tests__/ListFilters.test.tsx
+++ b/src/components/__tests__/ListFilters.test.tsx
@@ -59,36 +59,36 @@ const availabilityFacet: FacetGroupData = {
 };
 
 test("renders sort by select with correct options", () => {
-  const node = render(<ListFilters />, {
+  const utils = render(<ListFilters />, {
     initialState: stateWithFacets([sortByFacet])
   });
 
-  const facet = node.getByLabelText("Sort by");
-  expect(node.getByText("author")).toBeInTheDocument();
-  expect(node.getByText("title")).toBeInTheDocument();
+  const facet = utils.getByLabelText("Sort by");
+  expect(utils.getByText("author")).toBeInTheDocument();
+  expect(utils.getByText("title")).toBeInTheDocument();
 
   expect(facet).toHaveValue("author");
 });
 
 test("renders availability select with correct options", () => {
-  const node = render(<ListFilters />, {
+  const utils = render(<ListFilters />, {
     initialState: stateWithFacets([availabilityFacet])
   });
 
-  const facet = node.getByLabelText("Availability");
-  expect(node.getByText("All")).toBeInTheDocument();
-  expect(node.getByText("Yours to keep")).toBeInTheDocument();
-  expect(node.getByText("Available now")).toBeInTheDocument();
+  const facet = utils.getByLabelText("Availability");
+  expect(utils.getByText("All")).toBeInTheDocument();
+  expect(utils.getByText("Yours to keep")).toBeInTheDocument();
+  expect(utils.getByText("Available now")).toBeInTheDocument();
 
   expect(facet).toHaveValue("All");
 });
 
 test("does redirect when selected", () => {
-  const node = render(<ListFilters />, {
+  const utils = render(<ListFilters />, {
     initialState: stateWithFacets([sortByFacet])
   });
 
-  const facet = node.getByLabelText("Sort by");
+  const facet = utils.getByLabelText("Sort by");
 
   userEvent.selectOptions(facet, "title");
 

--- a/src/components/__tests__/ListView.test.tsx
+++ b/src/components/__tests__/ListView.test.tsx
@@ -7,13 +7,13 @@ import { BookData } from "opds-web-client/lib/interfaces";
 const books = fixtures.makeBooks(3);
 
 test("renders books", () => {
-  const node = render(<ListView books={books} />);
+  const utils = render(<ListView books={books} />);
 
   function expectBook(i: number) {
     const book = fixtures.makeBook(i);
-    expect(node.getByText(book.title)).toBeInTheDocument();
+    expect(utils.getByText(book.title)).toBeInTheDocument();
     // shows details as well
-    expect(node.getByText(book.authors[0])).toBeInTheDocument();
+    expect(utils.getByText(book.authors[0])).toBeInTheDocument();
   }
 
   expectBook(0);
@@ -25,9 +25,9 @@ test("truncates long titles", () => {
   const longBook = merge<BookData>(fixtures.book, {
     title: "This is an extremely long title it's really way too long"
   });
-  const node = render(<ListView books={[longBook]} />);
+  const utils = render(<ListView books={[longBook]} />);
 
-  const title = node.getByText(/This is an extremely/i);
+  const title = utils.getByText(/This is an extremely/i);
   expect(title.textContent).toHaveLength(50);
 });
 
@@ -41,8 +41,8 @@ test("truncates authors", () => {
       arrayMerge: (a, b) => b
     }
   );
-  const node = render(<ListView books={[longBook]} />);
+  const utils = render(<ListView books={[longBook]} />);
 
-  expect(node.getByText("one, two & 3 more"));
-  expect(node.queryByText("one, two, three")).toBeFalsy();
+  expect(utils.getByText("one, two & 3 more"));
+  expect(utils.queryByText("one, two, three")).toBeFalsy();
 });

--- a/src/components/__tests__/MyBooks.test.tsx
+++ b/src/components/__tests__/MyBooks.test.tsx
@@ -9,12 +9,12 @@ import { mockPush } from "../../test-utils/mockNextRouter";
 const mockSetCollectionAndBook = jest.fn().mockReturnValue(Promise.resolve({}));
 
 test("shows message and button when not authenticated", () => {
-  const node = render(
+  const utils = render(
     <MyBooks setCollectionAndBook={mockSetCollectionAndBook} />
   );
 
   expect(
-    node.getByText("You need to be signed in to view this page.")
+    utils.getByText("You need to be signed in to view this page.")
   ).toBeInTheDocument();
 });
 
@@ -30,43 +30,43 @@ const emptyWithAuth: State = merge(fixtures.initialState, {
 });
 
 test("displays empty state when empty and signed in", () => {
-  const node = render(
+  const utils = render(
     <MyBooks setCollectionAndBook={mockSetCollectionAndBook} />,
     { initialState: emptyWithAuth }
   );
 
   expect(
-    node.queryByText("You need to be signed in to view this page.")
+    utils.queryByText("You need to be signed in to view this page.")
   ).toBeFalsy();
 
   expect(
-    node.getByText(
+    utils.getByText(
       "Your books will show up here when you have any loaned or on hold."
     )
   ).toBeInTheDocument();
 
-  expect(node.getByText("Sign Out")).toBeInTheDocument();
+  expect(utils.getByText("Sign Out")).toBeInTheDocument();
 });
 
 test("sign out clears state and goes home", () => {
-  const node = render(
+  const utils = render(
     <MyBooks setCollectionAndBook={mockSetCollectionAndBook} />,
     { initialState: emptyWithAuth }
   );
 
-  const signOut = node.getByText("Sign Out");
+  const signOut = utils.getByText("Sign Out");
   fireEvent.click(signOut);
 
   expect(mockPush).toHaveBeenCalledTimes(1);
   expect(mockPush).toHaveBeenCalledWith("/", undefined);
 
-  expect(node.store.getState().auth.credentials).toBeFalsy();
+  expect(utils.store.getState().auth.credentials).toBeFalsy();
   /**
    * even though the location shows home, we should still be able to assert on the MyBooks
    * because we are rendering it no matter what route we are on
    */
   expect(
-    node.getByText("You need to be signed in to view this page.")
+    utils.getByText("You need to be signed in to view this page.")
   ).toBeInTheDocument();
 });
 
@@ -82,26 +82,26 @@ const withAuthAndBooks: State = merge(fixtures.initialState, {
 });
 
 test("displays books when signed in with data", () => {
-  const node = render(
+  const utils = render(
     <MyBooks setCollectionAndBook={mockSetCollectionAndBook} />,
     { initialState: withAuthAndBooks }
   );
 
   expect(
-    node.queryByText("You need to be signed in to view this page.")
+    utils.queryByText("You need to be signed in to view this page.")
   ).toBeFalsy();
 
   expect(
-    node.queryByText(
+    utils.queryByText(
       "Your books will show up here when you have any loaned or on hold."
     )
   ).toBeFalsy();
 
-  expect(node.getByText(fixtures.makeBook(0).title)).toBeInTheDocument();
-  expect(node.getByText(fixtures.makeBook(9).title)).toBeInTheDocument();
+  expect(utils.getByText(fixtures.makeBook(0).title)).toBeInTheDocument();
+  expect(utils.getByText(fixtures.makeBook(9).title)).toBeInTheDocument();
 
   expect(
-    node.getByText(fixtures.makeBook(0).authors.join(", "))
+    utils.getByText(fixtures.makeBook(0).authors.join(", "))
   ).toBeInTheDocument();
 });
 
@@ -132,12 +132,14 @@ const loading: State = merge(fixtures.initialState, {
 });
 
 test("shows loading state", () => {
-  const node = render(
+  const utils = render(
     <MyBooks setCollectionAndBook={mockSetCollectionAndBook} />,
     {
       initialState: loading
     }
   );
 
-  expect(node.getByRole("heading", { name: "Loading..." })).toBeInTheDocument();
+  expect(
+    utils.getByRole("heading", { name: "Loading..." })
+  ).toBeInTheDocument();
 });

--- a/src/components/__tests__/PageTitle.test.tsx
+++ b/src/components/__tests__/PageTitle.test.tsx
@@ -54,27 +54,27 @@ const stateWithFacets: State = merge<State>(fixtures.initialState, {
 
 describe("Format filters", () => {
   test("Format filters not rendered when not in state", () => {
-    const node = render(<PageTitle>Child</PageTitle>);
-    expect(node.queryByLabelText("Format filters")).toBeFalsy();
-    expect(node.queryByText("All")).toBeFalsy();
-    expect(node.queryByLabelText("Books")).toBeFalsy();
-    expect(node.queryByLabelText("Audiobooks")).toBeFalsy();
+    const utils = render(<PageTitle>Child</PageTitle>);
+    expect(utils.queryByLabelText("Format filters")).toBeFalsy();
+    expect(utils.queryByText("All")).toBeFalsy();
+    expect(utils.queryByLabelText("Books")).toBeFalsy();
+    expect(utils.queryByLabelText("Audiobooks")).toBeFalsy();
   });
   test("Format filters are visible in PageTitle w/ facets", () => {
-    const node = render(<PageTitle>Child</PageTitle>, {
+    const utils = render(<PageTitle>Child</PageTitle>, {
       initialState: stateWithFacets
     });
-    expect(node.getByRole("option", { name: "All" })).toBeTruthy();
-    expect(node.getByRole("option", { name: "eBooks" })).toBeTruthy();
-    expect(node.getByRole("option", { name: "Audiobooks" })).toBeTruthy();
+    expect(utils.getByRole("option", { name: "All" })).toBeTruthy();
+    expect(utils.getByRole("option", { name: "eBooks" })).toBeTruthy();
+    expect(utils.getByRole("option", { name: "Audiobooks" })).toBeTruthy();
   });
 
   test("format filters navigate to respective urls", async () => {
-    const node = render(<PageTitle>Child</PageTitle>, {
+    const utils = render(<PageTitle>Child</PageTitle>, {
       initialState: stateWithFacets
     });
 
-    const select = node.getByRole("combobox", {
+    const select = utils.getByRole("combobox", {
       name: "Format"
     }) as HTMLSelectElement;
     // all is selected

--- a/src/components/__tests__/Search.test.tsx
+++ b/src/components/__tests__/Search.test.tsx
@@ -10,7 +10,7 @@ test("fetches search description", async () => {
     actions,
     "fetchSearchDescription"
   );
-  const node = render(<Search />, {
+  const utils = render(<Search />, {
     initialState: merge(fixtures.initialState, {
       collection: {
         data: {
@@ -24,12 +24,12 @@ test("fetches search description", async () => {
 
   expect(mockedFetchSearchDescription).toHaveBeenCalledTimes(1);
   expect(mockedFetchSearchDescription).toHaveBeenCalledWith("/search-url");
-  expect(node.dispatch).toHaveBeenCalledTimes(1);
+  expect(utils.dispatch).toHaveBeenCalledTimes(1);
 });
 
 test("searching calls history.push with url", async () => {
   const mockedTemplate = jest.fn().mockReturnValue("templatereturn");
-  const node = render(<Search />, {
+  const utils = render(<Search />, {
     initialState: merge(fixtures.initialState, {
       collection: {
         data: {
@@ -43,8 +43,8 @@ test("searching calls history.push with url", async () => {
       }
     })
   });
-  const searchButton = node.getByText("Search");
-  const input = node.getByLabelText("Enter search keyword or keywords");
+  const searchButton = utils.getByText("Search");
+  const input = utils.getByLabelText("Enter search keyword or keywords");
   // act
   userEvent.type(input, "my search");
   fireEvent.click(searchButton);

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -5,14 +5,14 @@ import { render } from "../../test-utils";
 import TextInput, { TextArea } from "../TextInput";
 
 test("TextInput renders properly and passes styles through", () => {
-  const node = render(<TextInput sx={{ color: "red" }} />);
-  expect(node.container.firstChild).toMatchSnapshot();
+  const utils = render(<TextInput sx={{ color: "red" }} />);
+  expect(utils.container.firstChild).toMatchSnapshot();
 
-  expect(node.container.firstChild).toHaveStyle("color: red");
+  expect(utils.container.firstChild).toHaveStyle("color: red");
 });
 
 test("type textarea renders properly and passes styles throug", () => {
-  const node = render(<TextArea sx={{ color: "maroon" }} />);
-  expect(node.container.firstChild).toMatchSnapshot();
-  expect(node.container.firstChild).toHaveStyle("color: maroon");
+  const utils = render(<TextArea sx={{ color: "maroon" }} />);
+  expect(utils.container.firstChild).toMatchSnapshot();
+  expect(utils.container.firstChild).toHaveStyle("color: maroon");
 });

--- a/src/components/__tests__/form.test.tsx
+++ b/src/components/__tests__/form.test.tsx
@@ -3,28 +3,28 @@ import { render } from "../../test-utils";
 import FormInput from "../form/FormInput";
 
 test("renders as expected", () => {
-  const node = render(<FormInput name="input-name" label="Email" />);
-  expect(node.container.firstChild).toMatchSnapshot();
+  const utils = render(<FormInput name="input-name" label="Email" />);
+  expect(utils.container.firstChild).toMatchSnapshot();
 });
 
 test("displays star when required", () => {
-  const node = render(<FormInput required name="input-name" label="Email" />);
-  expect(node.getByText("*")).toBeInTheDocument();
+  const utils = render(<FormInput required name="input-name" label="Email" />);
+  expect(utils.getByText("*")).toBeInTheDocument();
 });
 
 test("no star when not required", () => {
-  const node = render(<FormInput name="input-name" label="Email" />);
-  expect(node.queryByText("*")).toBeNull();
+  const utils = render(<FormInput name="input-name" label="Email" />);
+  expect(utils.queryByText("*")).toBeNull();
 });
 
 test("displays label", () => {
-  const node = render(<FormInput name="input-name" label="Email" />);
-  expect(node.getByText("Email")).toBeInTheDocument();
+  const utils = render(<FormInput name="input-name" label="Email" />);
+  expect(utils.getByText("Email")).toBeInTheDocument();
 });
 
 test("shows error when present", () => {
-  const node = render(
+  const utils = render(
     <FormInput name="input-name" label="Email" error="Something went wrong" />
   );
-  expect(node.getByText("Something went wrong")).toBeInTheDocument();
+  expect(utils.getByText("Something went wrong")).toBeInTheDocument();
 });

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -31,7 +31,7 @@ const makeStateWithBook = (book: BookData = fixtures.book): State =>
 
 describe("book details page", () => {
   test("shows loading state", () => {
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: merge<State>(fixtures.initialState, {
@@ -45,12 +45,12 @@ describe("book details page", () => {
       }
     );
     expect(
-      node.getByRole("heading", { name: "Loading..." })
+      utils.getByRole("heading", { name: "Loading..." })
     ).toBeInTheDocument();
   });
 
   test("handles error state", () => {
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: merge<State>(fixtures.initialState, {
@@ -70,36 +70,36 @@ describe("book details page", () => {
     /**
      * We will snapshot test this component because it isn't complicated and should prettymuch remain the same.
      */
-    expect(node.container).toMatchSnapshot();
+    expect(utils.container).toMatchSnapshot();
   });
 
   test("shows categories", () => {
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: makeStateWithBook()
       }
     );
     const categories = fixtures.book.categories?.join(", ") as string;
-    expect(node.getByText(categories));
-    expect(node.getByText("Categories:"));
+    expect(utils.getByText(categories));
+    expect(utils.getByText("Categories:"));
   });
 
   test("doesn't show categories when there aren't any", () => {
     const bookWithoutCategories: BookData = merge(fixtures.book, {
       categories: null
     });
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: makeStateWithBook(bookWithoutCategories)
       }
     );
-    expect(node.queryByText("Categories:")).toBeFalsy();
+    expect(utils.queryByText("Categories:")).toBeFalsy();
   });
 
   test("shows publisher", () => {
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: makeStateWithBook()
@@ -107,12 +107,12 @@ describe("book details page", () => {
     );
     const publisher = fixtures.book.publisher as string;
 
-    expect(node.getByText(publisher)).toBeInTheDocument();
-    expect(node.getByText("Publisher:")).toBeInTheDocument();
+    expect(utils.getByText(publisher)).toBeInTheDocument();
+    expect(utils.getByText("Publisher:")).toBeInTheDocument();
   });
 
   test("shows fulfillment card in open-access state", () => {
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: makeStateWithBook()
@@ -120,34 +120,34 @@ describe("book details page", () => {
     );
 
     expect(
-      node.getByText("This open-access book is available to keep forever.")
+      utils.getByText("This open-access book is available to keep forever.")
     );
-    const epubDownload = node.getByRole("link", { name: "Download EPUB" });
+    const epubDownload = utils.getByRole("link", { name: "Download EPUB" });
     expect(epubDownload).toBeInTheDocument();
     expect(epubDownload).toHaveAttribute("href", "/epub-open-access-link");
 
-    const pdfDownload = node.getByRole("link", { name: "Download PDF" });
+    const pdfDownload = utils.getByRole("link", { name: "Download PDF" });
     expect(pdfDownload).toBeInTheDocument();
     expect(pdfDownload).toHaveAttribute("href", "/pdf-open-access-link");
   });
 
   test("shows simplyE callout", async () => {
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: makeStateWithBook()
       }
     );
 
-    expect(node.getByText("Read Now. Read Everywhere.")).toBeInTheDocument();
-    expect(node.getByLabelText("SimplyE Logo")).toBeInTheDocument();
+    expect(utils.getByText("Read Now. Read Everywhere.")).toBeInTheDocument();
+    expect(utils.getByLabelText("SimplyE Logo")).toBeInTheDocument();
     expect(
-      node.getByText(
+      utils.getByText(
         "Browse and read our collection of eBooks and Audiobooks right from your phone."
       )
     ).toBeInTheDocument();
 
-    const iosBadge = node.getByRole("link", {
+    const iosBadge = utils.getByRole("link", {
       name: "Download SimplyE on the Apple App Store",
       hidden: true // it is initially hidden by a media query, only displayed on desktop
     });
@@ -157,7 +157,7 @@ describe("book details page", () => {
       "https://apps.apple.com/us/app/simplye/id1046583900"
     );
 
-    const googleBadge = node.getByRole("link", {
+    const googleBadge = utils.getByRole("link", {
       name: "Get SimplyE on the Google Play Store",
       hidden: true // hidden initially on mobile
     });
@@ -169,7 +169,7 @@ describe("book details page", () => {
   });
 
   test("shows recommendation lanes", () => {
-    const node = render(
+    const utils = render(
       <RecommendationsStateContext.Provider
         value={{
           ...fixtures.recommendationsState
@@ -181,9 +181,9 @@ describe("book details page", () => {
         initialState: makeStateWithBook()
       }
     );
-    expect(node.getByText("Recommendations")).toBeInTheDocument();
+    expect(utils.getByText("Recommendations")).toBeInTheDocument();
     expect(
-      node.getByRole("heading", { name: "Jane Austen" })
+      utils.getByRole("heading", { name: "Jane Austen" })
     ).toBeInTheDocument();
   });
 });
@@ -218,37 +218,37 @@ const bookWithReportUrl = merge<BookData>(fixtures.book, {
 
 describe("report problem", () => {
   test("shows report problem link", () => {
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: makeStateWithBook()
       }
     );
 
-    const reportProblemLink = node.getByTestId("report-problem-link");
+    const reportProblemLink = utils.getByTestId("report-problem-link");
     expect(reportProblemLink).toBeInTheDocument();
   });
 
   test("shows form (only) when clicked", async () => {
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: makeStateWithBook()
       }
     );
     // make sure it's not visible at first
-    expect(node.getByLabelText("Complaint Type")).not.toBeVisible();
+    expect(utils.getByLabelText("Complaint Type")).not.toBeVisible();
 
-    const reportProblemLink = node.getByTestId("report-problem-link");
+    const reportProblemLink = utils.getByTestId("report-problem-link");
     userEvent.click(reportProblemLink);
 
     // one for the original report problem button, one for the form
-    expect(node.getAllByText("Report a problem")).toHaveLength(2);
-    expect(node.getByLabelText("Complaint Type")).toBeVisible();
-    expect(node.getByLabelText("Details")).toBeVisible();
-    expect(node.getByText("Cancel")).toBeVisible();
-    expect(node.getByText("Submit")).toBeVisible();
-    expect(node.getByText("Submit")).toHaveAttribute("type", "submit");
+    expect(utils.getAllByText("Report a problem")).toHaveLength(2);
+    expect(utils.getByLabelText("Complaint Type")).toBeVisible();
+    expect(utils.getByLabelText("Details")).toBeVisible();
+    expect(utils.getByText("Cancel")).toBeVisible();
+    expect(utils.getByText("Submit")).toBeVisible();
+    expect(utils.getByText("Submit")).toHaveAttribute("type", "submit");
   });
 
   test("fetches complaint types", async () => {
@@ -278,24 +278,24 @@ describe("report problem", () => {
     const mockBoundPostComplaint = jest.fn().mockResolvedValue(["some-string"]);
     postComplaintSpy.mockReturnValue(_url => mockBoundPostComplaint);
 
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: makeStateWithBook(bookWithReportUrl)
       }
     );
     // open the form
-    const reportProblemLink = node.getByTestId("report-problem-link");
+    const reportProblemLink = utils.getByTestId("report-problem-link");
     userEvent.click(reportProblemLink);
 
     // fill the form
     userEvent.selectOptions(
-      node.getByLabelText("Complaint Type"),
+      utils.getByLabelText("Complaint Type"),
       "complaint-type-b"
     );
-    userEvent.type(node.getByLabelText("Details"), "Some issue happened.");
+    userEvent.type(utils.getByLabelText("Details"), "Some issue happened.");
     // submit the form
-    userEvent.click(node.getByText("Submit"));
+    userEvent.click(utils.getByText("Submit"));
 
     // actually posted the complaint
     await waitFor(() =>
@@ -323,56 +323,56 @@ describe("report problem", () => {
       return Promise.resolve(["some string"]);
     });
 
-    const node = render(
+    const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {
         initialState: makeStateWithBook(bookWithReportUrl)
       }
     );
     // open the form
-    const reportProblemLink = node.getByTestId("report-problem-link");
+    const reportProblemLink = utils.getByTestId("report-problem-link");
     userEvent.click(reportProblemLink);
 
     // fill the form
     userEvent.selectOptions(
-      node.getByLabelText("Complaint Type"),
+      utils.getByLabelText("Complaint Type"),
       "complaint-type-b"
     );
-    userEvent.type(node.getByLabelText("Details"), "Some issue happened.");
+    userEvent.type(utils.getByLabelText("Details"), "Some issue happened.");
     // submit the form
-    userEvent.click(node.getByText("Submit"));
+    userEvent.click(utils.getByText("Submit"));
 
     // shows thank you message
     expect(
-      await node.findByText("Your problem was reported. Thank you!")
+      await utils.findByText("Your problem was reported. Thank you!")
     ).toBeInTheDocument();
-    expect(await node.findByText("Done")).toBeInTheDocument();
+    expect(await utils.findByText("Done")).toBeInTheDocument();
 
     // can close the form
-    userEvent.click(node.getByText("Done"));
-    expect(node.getByText("Complaint Type")).not.toBeVisible();
+    userEvent.click(utils.getByText("Done"));
+    expect(utils.getByText("Complaint Type")).not.toBeVisible();
   });
 
   test("displays client error when unfilled", async () => {
     const mockBoundPostComplaint = jest.fn().mockResolvedValue(["some-string"]);
     postComplaintSpy.mockReturnValue(_url => mockBoundPostComplaint);
 
-    const node = render(<ReportProblem book={fixtures.book} />, {
+    const utils = render(<ReportProblem book={fixtures.book} />, {
       initialState: makeStateWithBook(bookWithReportUrl)
     });
     // open the form
-    const reportProblemLink = node.getByTestId("report-problem-link");
+    const reportProblemLink = utils.getByTestId("report-problem-link");
     userEvent.click(reportProblemLink);
 
     // don't fill the form
     // submit the form
-    userEvent.click(node.getByText("Submit"));
+    userEvent.click(utils.getByText("Submit"));
 
     expect(
-      await node.findByText("Error: Please choose a type")
+      await utils.findByText("Error: Please choose a type")
     ).toBeInTheDocument();
     expect(
-      await node.findByText("Error: Please enter details about the problem.")
+      await utils.findByText("Error: Please enter details about the problem.")
     ).toBeInTheDocument();
 
     expect(mockBoundPostComplaint).toHaveBeenCalledTimes(0);

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -9,23 +9,23 @@ import { State } from "opds-web-client/lib/state";
 
 describe("open-access", () => {
   test("correct title and subtitle", () => {
-    const node = render(<FulfillmentCard book={fixtures.book} />);
+    const utils = render(<FulfillmentCard book={fixtures.book} />);
     expect(
-      node.getByText("This open-access book is available to keep forever.")
+      utils.getByText("This open-access book is available to keep forever.")
     ).toBeInTheDocument();
-    expect(node.getByText("You're ready to read this book in SimplyE!"));
+    expect(utils.getByText("You're ready to read this book in SimplyE!"));
   });
   test("shows download options", () => {
-    const node = render(<FulfillmentCard book={fixtures.book} />);
+    const utils = render(<FulfillmentCard book={fixtures.book} />);
     expect(
-      node.getByText("If you would rather read on your computer, you can:")
+      utils.getByText("If you would rather read on your computer, you can:")
     );
-    const downloadButton = node.getByText("Download EPUB");
+    const downloadButton = utils.getByText("Download EPUB");
     expect(downloadButton).toBeInTheDocument();
     expect(downloadButton).toHaveAttribute("target", "__blank");
     expect(downloadButton).toHaveAttribute("href", "/epub-open-access-link");
 
-    const PDFButton = node.getByText("Download PDF");
+    const PDFButton = utils.getByText("Download PDF");
     expect(PDFButton).toBeInTheDocument();
     expect(PDFButton).toHaveAttribute("target", "__blank");
     expect(PDFButton).toHaveAttribute("href", "/pdf-open-access-link");
@@ -44,8 +44,8 @@ describe("open-access", () => {
         }
       ]
     });
-    const node = render(<FulfillmentCard book={bookWithDuplicateFormat} />);
-    const downloadButton = node.getAllByText("Download PDF");
+    const utils = render(<FulfillmentCard book={bookWithDuplicateFormat} />);
+    const downloadButton = utils.getAllByText("Download PDF");
     expect(downloadButton).toHaveLength(1);
   });
 });
@@ -59,15 +59,15 @@ describe("available to borrow", () => {
     }
   });
   test("correct title and subtitle", () => {
-    const node = render(<FulfillmentCard book={closedAccessBook} />);
+    const utils = render(<FulfillmentCard book={closedAccessBook} />);
     expect(
-      node.getByText("This book is available to borrow!")
+      utils.getByText("This book is available to borrow!")
     ).toBeInTheDocument();
-    expect(node.getByText("10 out of 13 copies available."));
+    expect(utils.getByText("10 out of 13 copies available."));
   });
   test("displays borrow button", () => {
-    const node = render(<FulfillmentCard book={closedAccessBook} />);
-    const borrowButton = node.getByText("Borrow");
+    const utils = render(<FulfillmentCard book={closedAccessBook} />);
+    const borrowButton = utils.getByText("Borrow");
     expect(borrowButton).toBeInTheDocument();
   });
 
@@ -84,7 +84,7 @@ describe("available to borrow", () => {
       );
     // also spy on fetchLoans
     const fetchLoansSpy = jest.spyOn(actions, "fetchLoans");
-    const node = render(<FulfillmentCard book={closedAccessBook} />, {
+    const utils = render(<FulfillmentCard book={closedAccessBook} />, {
       initialState: merge<State>(fixtures.initialState, {
         loans: {
           url: "/loans-url",
@@ -93,10 +93,10 @@ describe("available to borrow", () => {
       })
     });
     // click borrow
-    userEvent.click(node.getByText("Borrow"));
+    userEvent.click(utils.getByText("Borrow"));
     expect(updateBookSpy).toHaveBeenCalledTimes(1);
     expect(updateBookSpy).toHaveBeenCalledWith("borrow url");
-    const borrowButton = await node.findByRole("button", {
+    const borrowButton = await utils.findByRole("button", {
       name: "Borrowing..."
     });
     expect(borrowButton).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe("available to borrow", () => {
       status: 403,
       url: "error-url"
     };
-    const node = render(<FulfillmentCard book={closedAccessBook} />, {
+    const utils = render(<FulfillmentCard book={closedAccessBook} />, {
       initialState: merge(fixtures.initialState, {
         book: {
           error: err
@@ -119,10 +119,10 @@ describe("available to borrow", () => {
       })
     });
     expect(
-      node.getByText("10 out of 13 copies available.")
+      utils.getByText("10 out of 13 copies available.")
     ).toBeInTheDocument();
     expect(
-      node.getByText("Error: cannot loan more than 3 documents.")
+      utils.getByText("Error: cannot loan more than 3 documents.")
     ).toBeInTheDocument();
   });
 });
@@ -137,9 +137,11 @@ describe("ready to borrow", () => {
     }
   });
   test("correct title and subtitle", () => {
-    const node = render(<FulfillmentCard book={readyBook} />);
-    expect(node.getByText("You can now borrow this book!")).toBeInTheDocument();
-    expect(node.getByText("Your hold will expire on Tue Jun 16 2020."));
+    const utils = render(<FulfillmentCard book={readyBook} />);
+    expect(
+      utils.getByText("You can now borrow this book!")
+    ).toBeInTheDocument();
+    expect(utils.getByText("Your hold will expire on Tue Jun 16 2020."));
   });
   test("shows loading state when borrowing, borrows, and refetches loans", async () => {
     // mock the actions.updateBook
@@ -154,7 +156,7 @@ describe("ready to borrow", () => {
       );
     // also spy on fetchLoans
     const fetchLoansSpy = jest.spyOn(actions, "fetchLoans");
-    const node = render(<FulfillmentCard book={readyBook} />, {
+    const utils = render(<FulfillmentCard book={readyBook} />, {
       initialState: merge<State>(fixtures.initialState, {
         loans: {
           url: "/loans-url",
@@ -163,10 +165,10 @@ describe("ready to borrow", () => {
       })
     });
     // click borrow
-    userEvent.click(node.getByText("Borrow"));
+    userEvent.click(utils.getByText("Borrow"));
     expect(updateBookSpy).toHaveBeenCalledTimes(1);
     expect(updateBookSpy).toHaveBeenCalledWith("borrow url");
-    const borrowButton = await node.findByRole("button", {
+    const borrowButton = await utils.findByRole("button", {
       name: "Borrowing..."
     });
     expect(borrowButton).toBeInTheDocument();
@@ -181,7 +183,7 @@ describe("ready to borrow", () => {
       status: 403,
       url: "error-url"
     };
-    const node = render(<FulfillmentCard book={readyBook} />, {
+    const utils = render(<FulfillmentCard book={readyBook} />, {
       initialState: merge(fixtures.initialState, {
         book: {
           error: err
@@ -189,7 +191,7 @@ describe("ready to borrow", () => {
       })
     });
     expect(
-      node.getByText("Error: cannot loan more than 3 documents.")
+      utils.getByText("Error: cannot loan more than 3 documents.")
     ).toBeInTheDocument();
   });
   test("handles lack of availability.until info", () => {
@@ -197,9 +199,9 @@ describe("ready to borrow", () => {
       ...readyBook,
       availability: { status: "ready" }
     });
-    const node = render(<FulfillmentCard book={withoutCopies} />);
+    const utils = render(<FulfillmentCard book={withoutCopies} />);
     expect(
-      node.getByText("You must borrow this book before your loan expires.")
+      utils.getByText("You must borrow this book before your loan expires.")
     );
   });
 });
@@ -217,16 +219,18 @@ describe("available to reserve", () => {
   });
 
   test("correct title and subtitle", () => {
-    const node = render(<FulfillmentCard book={unavailableBook} />);
+    const utils = render(<FulfillmentCard book={unavailableBook} />);
     expect(
-      node.getByText("This book is currently unavailable.")
+      utils.getByText("This book is currently unavailable.")
     ).toBeInTheDocument();
-    expect(node.getByText("0 out of 13 copies available.")).toBeInTheDocument();
+    expect(
+      utils.getByText("0 out of 13 copies available.")
+    ).toBeInTheDocument();
   });
 
   test("displays reserve button", () => {
-    const node = render(<FulfillmentCard book={unavailableBook} />);
-    const reserveButton = node.getByRole("button", { name: "Reserve" });
+    const utils = render(<FulfillmentCard book={unavailableBook} />);
+    const reserveButton = utils.getByRole("button", { name: "Reserve" });
     expect(reserveButton).toBeInTheDocument();
   });
 
@@ -237,15 +241,17 @@ describe("available to reserve", () => {
         total: 4
       }
     });
-    const node = render(<FulfillmentCard book={bookWithQueue} />);
+    const utils = render(<FulfillmentCard book={bookWithQueue} />);
     expect(
-      node.getByText("0 out of 13 copies available. 4 patrons in the queue.")
+      utils.getByText("0 out of 13 copies available. 4 patrons in the queue.")
     );
   });
 
   test("doesn't show patrons in queue when holds info no present", () => {
-    const node = render(<FulfillmentCard book={unavailableBook} />);
-    expect(node.getByText("0 out of 13 copies available.")).toBeInTheDocument();
+    const utils = render(<FulfillmentCard book={unavailableBook} />);
+    expect(
+      utils.getByText("0 out of 13 copies available.")
+    ).toBeInTheDocument();
   });
 
   test("handles unknown availability numbers", () => {
@@ -256,8 +262,8 @@ describe("available to reserve", () => {
     // this is currently failing because the getFulfillmentState is returning error
     // since we expect to always have the availability numbers otherwise we don't know
     // if the book is available or not, unless there is some other way to tell that state.
-    const node = render(<FulfillmentCard book={bookWithQueue} />);
-    expect(node.getByText("Number of books available is unknown."));
+    const utils = render(<FulfillmentCard book={bookWithQueue} />);
+    expect(utils.getByText("Number of books available is unknown."));
   });
 
   test("shows loading state when reserving, reserves, and refetches loans", async () => {
@@ -273,7 +279,7 @@ describe("available to reserve", () => {
       );
     // also spy on fetchLoans
     const fetchLoansSpy = jest.spyOn(actions, "fetchLoans");
-    const node = render(<FulfillmentCard book={unavailableBook} />, {
+    const utils = render(<FulfillmentCard book={unavailableBook} />, {
       initialState: merge<State>(fixtures.initialState, {
         loans: {
           url: "/loans-url",
@@ -282,10 +288,10 @@ describe("available to reserve", () => {
       })
     });
     // click reserve
-    userEvent.click(node.getByText("Reserve"));
+    userEvent.click(utils.getByText("Reserve"));
     expect(updateBookSpy).toHaveBeenCalledTimes(1);
     expect(updateBookSpy).toHaveBeenCalledWith("borrow url");
-    const reserveButton = await node.findByRole("button", {
+    const reserveButton = await utils.findByRole("button", {
       name: "Reserving..."
     });
     expect(reserveButton).toBeInTheDocument();
@@ -308,8 +314,8 @@ describe("reserved", () => {
   });
 
   test("displays disabled reserve button", () => {
-    const node = render(<FulfillmentCard book={reservedBook} />);
-    const reserveButton = node.getByText("Reserved");
+    const utils = render(<FulfillmentCard book={reservedBook} />);
+    const reserveButton = utils.getByText("Reserved");
     expect(reserveButton).toBeInTheDocument();
     expect(reserveButton).toBeDisabled();
   });
@@ -329,8 +335,8 @@ describe("reserved", () => {
         position: 5
       }
     });
-    const node = render(<FulfillmentCard book={reservedBookWithQueue} />);
-    expect(node.getByText("Your hold position is: 5.")).toBeInTheDocument;
+    const utils = render(<FulfillmentCard book={reservedBookWithQueue} />);
+    expect(utils.getByText("Your hold position is: 5.")).toBeInTheDocument;
   });
 });
 
@@ -356,11 +362,11 @@ describe("available to download", () => {
   });
 
   test("correct title and subtitle", () => {
-    const node = render(<FulfillmentCard book={downloadableBook} />);
+    const utils = render(<FulfillmentCard book={downloadableBook} />);
     expect(
-      node.getByText("You have this book on loan until Thu Jun 18 2020.")
+      utils.getByText("You have this book on loan until Thu Jun 18 2020.")
     ).toBeInTheDocument();
-    expect(node.getByText("You're ready to read this book in SimplyE!"));
+    expect(utils.getByText("You're ready to read this book in SimplyE!"));
   });
 
   test("handles lack of availability info", () => {
@@ -368,28 +374,28 @@ describe("available to download", () => {
       ...downloadableBook,
       availability: undefined
     });
-    const node = render(<FulfillmentCard book={withoutAvailability} />);
-    expect(node.getByText("You have this book on loan.")).toBeInTheDocument();
-    expect(node.getByText("You're ready to read this book in SimplyE!"));
+    const utils = render(<FulfillmentCard book={withoutAvailability} />);
+    expect(utils.getByText("You have this book on loan.")).toBeInTheDocument();
+    expect(utils.getByText("You're ready to read this book in SimplyE!"));
   });
 
   test("shows download options", () => {
-    const node = render(<FulfillmentCard book={downloadableBook} />);
+    const utils = render(<FulfillmentCard book={downloadableBook} />);
     expect(
-      node.getByText("If you would rather read on your computer, you can:")
+      utils.getByText("If you would rather read on your computer, you can:")
     );
-    const downloadButton = node.getByText("Download EPUB");
+    const downloadButton = utils.getByText("Download EPUB");
     expect(downloadButton).toBeInTheDocument();
 
-    const PDFButton = node.getByText("Download PDF");
+    const PDFButton = utils.getByText("Download PDF");
     expect(PDFButton).toBeInTheDocument();
   });
 
   test("download button calls fulfillBook", () => {
     const fulfillBookSpy = jest.spyOn(actions, "fulfillBook");
 
-    const node = render(<FulfillmentCard book={downloadableBook} />);
-    const downloadButton = node.getByText("Download EPUB");
+    const utils = render(<FulfillmentCard book={downloadableBook} />);
+    const downloadButton = utils.getByText("Download EPUB");
     expect(downloadButton).toBeInTheDocument();
 
     userEvent.click(downloadButton);
@@ -412,8 +418,8 @@ describe("available to download", () => {
 
     const indirectFulfillSpy = jest.spyOn(actions, "indirectFulfillBook");
 
-    const node = render(<FulfillmentCard book={bookWithIndirect} />);
-    const downloadButton = node.getByText("Download atom");
+    const utils = render(<FulfillmentCard book={bookWithIndirect} />);
+    const downloadButton = utils.getByText("Download atom");
     expect(downloadButton).toBeInTheDocument();
 
     userEvent.click(downloadButton);
@@ -440,8 +446,8 @@ describe("available to download", () => {
 
     const indirectFulfillSpy = jest.spyOn(actions, "indirectFulfillBook");
 
-    const node = render(<FulfillmentCard book={bookWithIndirect} />);
-    const downloadButton = node.getByText("Read Online");
+    const utils = render(<FulfillmentCard book={bookWithIndirect} />);
+    const downloadButton = utils.getByText("Read Online");
     expect(downloadButton).toBeInTheDocument();
 
     userEvent.click(downloadButton);

--- a/src/components/bookDetails/__tests__/Recommendations.test.tsx
+++ b/src/components/bookDetails/__tests__/Recommendations.test.tsx
@@ -32,11 +32,13 @@ test("shows recommendations loading state", async () => {
    * wrap the BookDetails in a Provider so we can specify the recommendations state.
    * This will override the provider rendered in our custom `render` method
    */
-  const node = renderWithRecState(<Recommendations book={fixtures.book} />, {
+  const utils = renderWithRecState(<Recommendations book={fixtures.book} />, {
     ...fixtures.emptyRecommendationsState,
     isFetching: true
   });
-  await waitFor(() => expect(node.getByText("Loading...")).toBeInTheDocument());
+  await waitFor(() =>
+    expect(utils.getByText("Loading...")).toBeInTheDocument()
+  );
 });
 
 test("fetches the proper url for recommendation collection", () => {
@@ -46,26 +48,26 @@ test("fetches the proper url for recommendation collection", () => {
 });
 
 test("shows recommendation lanes", () => {
-  const node = renderWithRecState(<Recommendations book={fixtures.book} />);
+  const utils = renderWithRecState(<Recommendations book={fixtures.book} />);
   expect(
-    node.getByRole("heading", { name: "Recommendations" })
+    utils.getByRole("heading", { name: "Recommendations" })
   ).toBeInTheDocument();
   expect(
-    node.getByRole("heading", { name: "Jane Austen" })
+    utils.getByRole("heading", { name: "Jane Austen" })
   ).toBeInTheDocument();
 });
 
 test("doesn't show recommendations if there are none", () => {
-  const node = renderWithRecState(<Recommendations book={fixtures.book} />, {
+  const utils = renderWithRecState(<Recommendations book={fixtures.book} />, {
     ...fixtures.emptyRecommendationsState
   });
-  expect(node.container).toBeEmpty();
+  expect(utils.container).toBeEmpty();
 });
 
 test("recommendations are clickable", () => {
-  const node = renderWithRecState(<Recommendations book={fixtures.book} />);
+  const utils = renderWithRecState(<Recommendations book={fixtures.book} />);
 
-  const recommendationCover = node.getByRole("link", {
+  const recommendationCover = utils.getByRole("link", {
     name: "View Recommendation 1"
   });
   expect(recommendationCover.closest("a")).toHaveAttribute(
@@ -75,8 +77,8 @@ test("recommendations are clickable", () => {
 });
 
 test("displays a more button for recommendations", () => {
-  const node = renderWithRecState(<Recommendations book={fixtures.book} />);
-  const moreButton = node.getByText("See More");
+  const utils = renderWithRecState(<Recommendations book={fixtures.book} />);
+  const moreButton = utils.getByText("See More");
   expect(moreButton).toHaveAttribute(
     "href",
     "/collection/works%2Fcontributor%2FJane%2520Austen%2Feng"
@@ -90,9 +92,9 @@ const mockClearCollection = jest
   }));
 
 test("cleans up recommendations collection on unmount", () => {
-  const node = renderWithRecState(<Recommendations book={fixtures.book} />);
+  const utils = renderWithRecState(<Recommendations book={fixtures.book} />);
   expect(mockClearCollection).toHaveBeenCalledTimes(0);
-  node.unmount();
+  utils.unmount();
   expect(mockClearCollection).toHaveBeenCalledTimes(1);
 });
 
@@ -119,13 +121,13 @@ test("shows multiple lanes if existing", () => {
       ]
     }
   };
-  const node = renderWithRecState(
+  const utils = renderWithRecState(
     <Recommendations book={fixtures.book} />,
     stateWithMultipleLames
   );
 
-  expect(node.getByText("lane 1")).toBeInTheDocument();
-  expect(node.getByText("lane 2")).toBeInTheDocument();
+  expect(utils.getByText("lane 1")).toBeInTheDocument();
+  expect(utils.getByText("lane 2")).toBeInTheDocument();
 
-  expect(node.getAllByText("See More")).toHaveLength(2);
+  expect(utils.getAllByText("See More")).toHaveLength(2);
 });


### PR DESCRIPTION
This PR makes a simple language refactor across all of our test files and the readme. The result of `render` from `react-testing-library` is not actually a node. It is a set of utilities to query the dom by, as well as other utils we pass in via `test-utils/index.tsx`. I had started to transition slowly to using `utils` instead of `node`, but this should avoid confusion in the future.