### PR TITLE
Fix set state on unmounted component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.2.1
 
-- Fix: Only show download options for open-access books once they have been borrowed and are present in a user's loans. Download options should still be shown for open-access books in libraries that do not have any auth enabled. 
+- Fix: Only show download options for open-access books once they have been borrowed and are present in a user's loans. Download options should still be shown for open-access books in libraries that do not have any auth enabled.
+- Fix: Don't perform state update on unmounted `BorrowCard`. 
 
 ## 2.2.0
 

--- a/src/hooks/useBorrow.ts
+++ b/src/hooks/useBorrow.ts
@@ -5,6 +5,7 @@ import { getErrorMsg } from "utils/book";
 import { useActions } from "opds-web-client/lib/components/context/ActionsContext";
 
 export default function useBorrow(book: BookData) {
+  const isUnmounted = React.useRef(false);
   const [isLoading, setLoading] = React.useState(false);
   const bookError = useTypedSelector(state => state.book?.error);
   const errorMsg = getErrorMsg(bookError);
@@ -15,7 +16,7 @@ export default function useBorrow(book: BookData) {
     if (book.borrowUrl) {
       setLoading(true);
       await dispatch(actions.updateBook(book.borrowUrl));
-      setLoading(false);
+      if (!isUnmounted.current) setLoading(false);
     } else {
       throw Error("No borrow url present for book");
     }
@@ -24,6 +25,13 @@ export default function useBorrow(book: BookData) {
       await dispatch(actions.fetchLoans(loansUrl));
     }
   };
+
+  React.useEffect(
+    () => () => {
+      isUnmounted.current = true;
+    },
+    []
+  );
 
   return {
     isLoading,


### PR DESCRIPTION
This PR fixes a simple error we got in the borrow card where we would call `setLoading(false)` after the component had already mounted. We now track whether the component is mounted or not and only update the sate if it is still mounted (which would happen if there was an error in the borrow api call).