### PR TITLE
Add env variable to toggle SimplyE branding in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Set one of the following environment variables when running the application:
 
 The following environment variables can also be set to further configure the application.
 
-- Set `COMPANION_APP=openebooks` to display OpenE Books Branding (default displays SimplyE Branding).
+- Set `NEXT_PUBLIC_COMPANION_APP=openebooks` to display OpenE Books Branding (default displays SimplyE Branding).
 - Set `SHORTEN_URLS=false` to stop the app from removing common parts of the circulation manager URLs from the web app's URLs.
 - Set `CACHE_EXPIRATION_SECONDS` to control how often the app will check for changes to registry entries and circ manager authentication documents.
 - Set `AXE_TEST=true` to run the application with `react-axe` enabled (only works when `NODE_ENV` is "development").

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Set one of the following environment variables when running the application:
 
 The following environment variables can also be set to further configure the application.
 
+- Set `COMPANION_APP=openebooks` to display OpenE Books Branding (default displays SimplyE Branding).
 - Set `SHORTEN_URLS=false` to stop the app from removing common parts of the circulation manager URLs from the web app's URLs.
 - Set `CACHE_EXPIRATION_SECONDS` to control how often the app will check for changes to registry entries and circ manager authentication documents.
 - Set `AXE_TEST=true` to run the application with `react-axe` enabled (only works when `NODE_ENV` is "development").

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 const config = {
   env: {
-    NEXT_PUBLIC_COMPANION_APP: process.env.NEXT_PUBLIC_COMPANION_APP,
     SIMPLIFIED_CATALOG_BASE: process.env.SIMPLIFIED_CATALOG_BASE,
     SHORTEN_URLS: process.env.SHORTEN_URLS,
     CONFIG_FILE: process.env.CONFIG_FILE,

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 const config = {
   env: {
-    COMPANION_APP: process.env.COMPANION_APP || "simplye",
+    COMPANION_APP:  process.env.COMPANION_APP === "openebooks" ? "openebooks" : "simplye";
     SIMPLIFIED_CATALOG_BASE: process.env.SIMPLIFIED_CATALOG_BASE,
     SHORTEN_URLS: process.env.SHORTEN_URLS,
     CONFIG_FILE: process.env.CONFIG_FILE,

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 const config = {
   env: {
-    COMPANION_APP: process.env.COMPANION_APP,
+    COMPANION_APP: process.env.COMPANION_APP || "simplye",
     SIMPLIFIED_CATALOG_BASE: process.env.SIMPLIFIED_CATALOG_BASE,
     SHORTEN_URLS: process.env.SHORTEN_URLS,
     CONFIG_FILE: process.env.CONFIG_FILE,

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 const config = {
   env: {
-    COMPANION_APP:  process.env.COMPANION_APP === "openebooks" ? "openebooks" : "simplye";
+    COMPANION_APP:  process.env.COMPANION_APP === "openebooks" ? "openebooks" : "simplye",
     SIMPLIFIED_CATALOG_BASE: process.env.SIMPLIFIED_CATALOG_BASE,
     SHORTEN_URLS: process.env.SHORTEN_URLS,
     CONFIG_FILE: process.env.CONFIG_FILE,

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 const config = {
   env: {
+    COMPANION_APP: process.env.COMPANION_APP,
     SIMPLIFIED_CATALOG_BASE: process.env.SIMPLIFIED_CATALOG_BASE,
     SHORTEN_URLS: process.env.SHORTEN_URLS,
     CONFIG_FILE: process.env.CONFIG_FILE,

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 const config = {
   env: {
-    COMPANION_APP:  process.env.COMPANION_APP === "openebooks" ? "openebooks" : "simplye",
+    NEXT_PUBLIC_COMPANION_APP: process.env.NEXT_PUBLIC_COMPANION_APP,
     SIMPLIFIED_CATALOG_BASE: process.env.SIMPLIFIED_CATALOG_BASE,
     SHORTEN_URLS: process.env.SHORTEN_URLS,
     CONFIG_FILE: process.env.CONFIG_FILE,

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -97,7 +97,9 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
         </FooterList>
       </div>
       <div sx={{ flex: "1 1 0" }} />
-      {process.env.COMPANION_APP === "simplye" && <DownloadSimplyECallout />}
+      {process.env.NEXT_PUBLIC_COMPANION_APP === "simplye" && (
+        <DownloadSimplyECallout />
+      )}
     </footer>
   );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,6 +9,7 @@ import { NavButton } from "./Button";
 import SvgPhone from "icons/Phone";
 import IosBadge from "./storeBadges/IosBadge";
 import GooglePlayBadge from "./storeBadges/GooglePlayBadge";
+import { NEXT_PUBLIC_COMPANION_APP } from "../utils/env";
 
 const Footer: React.FC<{ className?: string }> = ({ className }) => {
   const library = useLibraryContext();
@@ -97,9 +98,7 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
         </FooterList>
       </div>
       <div sx={{ flex: "1 1 0" }} />
-      {process.env.NEXT_PUBLIC_COMPANION_APP === "simplye" && (
-        <DownloadSimplyECallout />
-      )}
+      {NEXT_PUBLIC_COMPANION_APP === "simplye" && <DownloadSimplyECallout />}
     </footer>
   );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,9 +9,6 @@ import { NavButton } from "./Button";
 import SvgPhone from "icons/Phone";
 import IosBadge from "./storeBadges/IosBadge";
 import GooglePlayBadge from "./storeBadges/GooglePlayBadge";
-import { COMPANION_APP } from "../utils/env";
-
-const SHOW_SIMPLYE_BRANDING = Boolean(COMPANION_APP === "simplye");
 
 const Footer: React.FC<{ className?: string }> = ({ className }) => {
   const library = useLibraryContext();
@@ -100,7 +97,7 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
         </FooterList>
       </div>
       <div sx={{ flex: "1 1 0" }} />
-      {SHOW_SIMPLYE_BRANDING && <DownloadSimplyECallout />}
+      {process.env.COMPANION_APP === "simplye" && <DownloadSimplyECallout />}
     </footer>
   );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,9 @@ import { NavButton } from "./Button";
 import SvgPhone from "icons/Phone";
 import IosBadge from "./storeBadges/IosBadge";
 import GooglePlayBadge from "./storeBadges/GooglePlayBadge";
-import { SHOW_SIMPLYE_BRANDING } from "../utils/env";
+import { COMPANION_APP } from "../utils/env";
+
+const SHOW_SIMPLYE_BRANDING = Boolean(COMPANION_APP === "simplye");
 
 const Footer: React.FC<{ className?: string }> = ({ className }) => {
   const library = useLibraryContext();
@@ -98,7 +100,6 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
         </FooterList>
       </div>
       <div sx={{ flex: "1 1 0" }} />
-
       {SHOW_SIMPLYE_BRANDING && <DownloadSimplyECallout />}
     </footer>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,6 +9,7 @@ import { NavButton } from "./Button";
 import SvgPhone from "icons/Phone";
 import IosBadge from "./storeBadges/IosBadge";
 import GooglePlayBadge from "./storeBadges/GooglePlayBadge";
+import { SHOW_SIMPLYE_BRANDING } from "../utils/env";
 
 const Footer: React.FC<{ className?: string }> = ({ className }) => {
   const library = useLibraryContext();
@@ -97,23 +98,28 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
         </FooterList>
       </div>
       <div sx={{ flex: "1 1 0" }} />
-      <div sx={{ maxWidth: 300, flex: "0 1 auto", mt: 5 }}>
-        <H3 sx={{ mt: 0, display: "flex", alignItems: "center" }}>
-          <SvgPhone sx={{ mr: 1 }} />
-          Download SimplyE
-        </H3>
-        <Text>
-          Our mobile app lets you browse, borrow and read from our whole
-          collection of eBooks and Audiobooks right on your phone!
-        </Text>
-        <div sx={{ width: "75%", overflow: "hidden", ml: -3 }}>
-          <IosBadge sx={{ p: 3, pb: 0 }} />
-          <GooglePlayBadge />
-        </div>
-      </div>
+
+      {SHOW_SIMPLYE_BRANDING && <DownloadSimplyECallout />}
     </footer>
   );
 };
+
+const DownloadSimplyECallout = () => (
+  <div sx={{ maxWidth: 300, flex: "0 1 auto", mt: 5 }}>
+    <H3 sx={{ mt: 0, display: "flex", alignItems: "center" }}>
+      <SvgPhone sx={{ mr: 1 }} />
+      Download SimplyE
+    </H3>
+    <Text>
+      Our mobile app lets you browse, borrow and read from our whole collection
+      of eBooks and Audiobooks right on your phone!
+    </Text>
+    <div sx={{ width: "75%", overflow: "hidden", ml: -3 }}>
+      <IosBadge sx={{ p: 3, pb: 0 }} />
+      <GooglePlayBadge />
+    </div>
+  </div>
+);
 
 const FooterList = (props: React.ComponentProps<typeof List>) => (
   <List

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -47,12 +47,7 @@ test("shows external links when present in state w/ apropriate attributes", () =
 });
 
 describe("toggling SimplyE Branding", () => {
-  beforeAll(() => {
-    jest.resetModules();
-  });
-
   test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {
-    process.env.NEXT_PUBLIC_COMPANION_APP = "openebooks";
     // @ts-ignore
     env.NEXT_PUBLIC_COMPANION_APP = "openebooks";
 

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -3,6 +3,7 @@ import { render, fixtures } from "../../test-utils";
 import merge from "deepmerge";
 import Footer from "components/Footer";
 import { LibraryData, Link } from "../../interfaces";
+import * as env from "../../utils/env";
 
 const link: Link = {
   href: "/wherever",
@@ -52,10 +53,11 @@ describe("toggling SimplyE Branding", () => {
 
   test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {
     process.env.NEXT_PUBLIC_COMPANION_APP = "openebooks";
+    // @ts-ignore
+    env.NEXT_PUBLIC_COMPANION_APP = "openebooks";
 
     const utils = render(<Footer />);
 
-    expect(process.env.NEXT_PUBLIC_COMPANION_APP).toBe("openebooks");
     expect(utils.queryByText(/download simplye/i)).not.toBeInTheDocument();
 
     expect(
@@ -83,13 +85,15 @@ describe("toggling SimplyE Branding", () => {
   });
 
   test("shows simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'simplye'", () => {
-    process.env.NEXT_PUBLIC_COMPANION_APP = "simplye";
+    // @ts-ignore
+    env.NEXT_PUBLIC_COMPANION_APP = "simplye";
 
     const utils = render(<Footer />);
 
-    expect(process.env.NEXT_PUBLIC_COMPANION_APP).toBe("simplye");
     expect(
-      utils.getByRole("heading", { name: /download simplye/i })
+      utils.getByRole("heading", {
+        name: /download simplye/i
+      })
     ).toBeInTheDocument();
 
     expect(
@@ -118,7 +122,9 @@ describe("toggling SimplyE Branding", () => {
     );
 
     // my books nav link
-    const myBooks = utils.getByRole("link", { name: /my books/i });
+    const myBooks = utils.getByRole("link", {
+      name: /my books/i
+    });
     expect(myBooks).toBeInTheDocument();
     expect(myBooks).toHaveAttribute("href", "/loans");
   });

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -45,39 +45,81 @@ test("shows external links when present in state w/ apropriate attributes", () =
   expect(myBooks).toHaveAttribute("href", "/loans");
 });
 
-test("shows simplyE callout", () => {
-  const utils = render(<Footer />);
-
-  expect(
-    utils.getByRole("heading", { name: /download simplye/i })
-  ).toBeInTheDocument();
-  expect(
-    utils.getByText(
-      "Our mobile app lets you browse, borrow and read from our whole collection of eBooks and Audiobooks right on your phone!"
-    )
-  ).toBeInTheDocument();
-
-  // badges
-  const iosbadge = utils.getByRole("link", {
-    name: /download simplye on the apple app store/i
+describe("toggling SimplyE Branding", () => {
+  beforeAll(() => {
+    jest.resetModules();
   });
-  expect(iosbadge).toBeInTheDocument();
-  expect(iosbadge).toHaveAttribute(
-    "href",
-    "https://apps.apple.com/us/app/simplye/id1046583900"
-  );
 
-  const googleBadge = utils.getByRole("link", {
-    name: /get simplye on the google play store/i
+  test("does not show simplyE callout", () => {
+    process.env.COMPANION_APP = "openebooks";
+
+    const utils = render(<Footer />);
+
+    expect(process.env.COMPANION_APP).toBe("openebooks");
+    expect(utils.queryByText(/download simplye/i)).not.toBeInTheDocument();
+
+    expect(
+      utils.queryByText(
+        "Our mobile app lets you browse, borrow and read from our whole collection of eBooks and Audiobooks right on your phone!"
+      )
+    ).not.toBeInTheDocument();
+
+    // badges
+    const iosbadge = utils.queryByText(
+      /download simplye on the apple app store/i
+    );
+
+    expect(iosbadge).not.toBeInTheDocument();
+
+    const googleBadge = utils.queryByText(
+      /get simplye on the google play store/
+    );
+    expect(googleBadge).not.toBeInTheDocument();
+
+    // my books nav link
+    const myBooks = utils.queryByText(/my books/i);
+    expect(myBooks).toBeInTheDocument();
+    expect(myBooks).toHaveAttribute("href", "/loans");
   });
-  expect(googleBadge).toBeInTheDocument();
-  expect(googleBadge).toHaveAttribute(
-    "href",
-    "https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
-  );
 
-  // my books nav link
-  const myBooks = utils.getByRole("link", { name: /my books/i });
-  expect(myBooks).toBeInTheDocument();
-  expect(myBooks).toHaveAttribute("href", "/loans");
+  test("shows simplyE callout", () => {
+    process.env.COMPANION_APP = "simplye";
+
+    const utils = render(<Footer />);
+
+    expect(process.env.COMPANION_APP).toBe("simplye");
+    expect(
+      utils.getByRole("heading", { name: /download simplye/i })
+    ).toBeInTheDocument();
+
+    expect(
+      utils.getByText(
+        "Our mobile app lets you browse, borrow and read from our whole collection of eBooks and Audiobooks right on your phone!"
+      )
+    ).toBeInTheDocument();
+
+    // badges
+    const iosbadge = utils.getByRole("link", {
+      name: /download simplye on the apple app store/i
+    });
+    expect(iosbadge).toBeInTheDocument();
+    expect(iosbadge).toHaveAttribute(
+      "href",
+      "https://apps.apple.com/us/app/simplye/id1046583900"
+    );
+
+    const googleBadge = utils.getByRole("link", {
+      name: /get simplye on the google play store/i
+    });
+    expect(googleBadge).toBeInTheDocument();
+    expect(googleBadge).toHaveAttribute(
+      "href",
+      "https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
+    );
+
+    // my books nav link
+    const myBooks = utils.getByRole("link", { name: /my books/i });
+    expect(myBooks).toBeInTheDocument();
+    expect(myBooks).toHaveAttribute("href", "/loans");
+  });
 });

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -50,7 +50,7 @@ describe("toggling SimplyE Branding", () => {
     jest.resetModules();
   });
 
-  test("does not show simplyE callout", () => {
+  test("does not show simplyE callout when COMPANION_APP is 'openebooks'", () => {
     process.env.COMPANION_APP = "openebooks";
 
     const utils = render(<Footer />);
@@ -82,7 +82,7 @@ describe("toggling SimplyE Branding", () => {
     expect(myBooks).toHaveAttribute("href", "/loans");
   });
 
-  test("shows simplyE callout", () => {
+  test("shows simplyE callout when COMPANION_APP is 'simplye'", () => {
     process.env.COMPANION_APP = "simplye";
 
     const utils = render(<Footer />);

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -48,10 +48,8 @@ test("shows external links when present in state w/ apropriate attributes", () =
 
 describe("toggling SimplyE Branding", () => {
   test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {
-    /* eslint-disable */
-    // @ts-ignore
-    env.NEXT_PUBLIC_COMPANION_APP = "openebooks";
-    /* eslint-enable*/
+    (env.NEXT_PUBLIC_COMPANION_APP as string) = "openebooks";
+
     const utils = render(<Footer />);
 
     expect(utils.queryByText(/download simplye/i)).not.toBeInTheDocument();
@@ -81,10 +79,7 @@ describe("toggling SimplyE Branding", () => {
   });
 
   test("shows simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'simplye'", () => {
-    /* eslint-disable */
-    // @ts-ignore
-    env.NEXT_PUBLIC_COMPANION_APP = "simplye";
-    /* eslint-enable */
+    (env.NEXT_PUBLIC_COMPANION_APP as string) = "simplye";
 
     const utils = render(<Footer />);
 

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -48,9 +48,10 @@ test("shows external links when present in state w/ apropriate attributes", () =
 
 describe("toggling SimplyE Branding", () => {
   test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {
+    /* eslint-disable */
     // @ts-ignore
     env.NEXT_PUBLIC_COMPANION_APP = "openebooks";
-
+    /* eslint-enable*/
     const utils = render(<Footer />);
 
     expect(utils.queryByText(/download simplye/i)).not.toBeInTheDocument();
@@ -80,8 +81,10 @@ describe("toggling SimplyE Branding", () => {
   });
 
   test("shows simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'simplye'", () => {
+    /* eslint-disable */
     // @ts-ignore
     env.NEXT_PUBLIC_COMPANION_APP = "simplye";
+    /* eslint-enable */
 
     const utils = render(<Footer />);
 

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -50,12 +50,12 @@ describe("toggling SimplyE Branding", () => {
     jest.resetModules();
   });
 
-  test("does not show simplyE callout when COMPANION_APP is 'openebooks'", () => {
-    process.env.COMPANION_APP = "openebooks";
+  test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {
+    process.env.NEXT_PUBLIC_COMPANION_APP = "openebooks";
 
     const utils = render(<Footer />);
 
-    expect(process.env.COMPANION_APP).toBe("openebooks");
+    expect(process.env.NEXT_PUBLIC_COMPANION_APP).toBe("openebooks");
     expect(utils.queryByText(/download simplye/i)).not.toBeInTheDocument();
 
     expect(
@@ -82,12 +82,12 @@ describe("toggling SimplyE Branding", () => {
     expect(myBooks).toHaveAttribute("href", "/loans");
   });
 
-  test("shows simplyE callout when COMPANION_APP is 'simplye'", () => {
-    process.env.COMPANION_APP = "simplye";
+  test("shows simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'simplye'", () => {
+    process.env.NEXT_PUBLIC_COMPANION_APP = "simplye";
 
     const utils = render(<Footer />);
 
-    expect(process.env.COMPANION_APP).toBe("simplye");
+    expect(process.env.NEXT_PUBLIC_COMPANION_APP).toBe("simplye");
     expect(
       utils.getByRole("heading", { name: /download simplye/i })
     ).toBeInTheDocument();

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -3,6 +3,11 @@
  * Simply exporting processed env vars
  */
 
+export const NEXT_PUBLIC_COMPANION_APP =
+  process.env.NEXT_PUBLIC_COMPANION_APP === "openebooks"
+    ? "openebooks"
+    : "simplye";
+
 export const SHORTEN_URLS = !(process.env.SHORTEN_URLS === "false");
 export const REGISTRY_BASE = process.env.REGISTRY_BASE;
 export const CIRCULATION_MANAGER_BASE = process.env.SIMPLIFIED_CATALOG_BASE;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,7 +4,7 @@
  */
 
 export const COMPANION_APP =
-  process.env.COMPANION_APP == "openebooks" ? "openebooks" : "simplye";
+  process.env.COMPANION_APP === "openebooks" ? "openebooks" : "simplye";
 
 export const SHORTEN_URLS = !(process.env.SHORTEN_URLS === "false");
 export const REGISTRY_BASE = process.env.REGISTRY_BASE;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -3,9 +3,6 @@
  * Simply exporting processed env vars
  */
 
-export const COMPANION_APP =
-  process.env.COMPANION_APP === "openebooks" ? "openebooks" : "simplye";
-
 export const SHORTEN_URLS = !(process.env.SHORTEN_URLS === "false");
 export const REGISTRY_BASE = process.env.REGISTRY_BASE;
 export const CIRCULATION_MANAGER_BASE = process.env.SIMPLIFIED_CATALOG_BASE;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,8 +4,8 @@
  */
 
 export const COMPANION_APP =
-  process.env.COMPANION_APP === "openebooks" ? "openebooks" : "simplye";
-export const SHOW_SIMPLYE_BRANDING = COMPANION_APP === "simplye";
+  process.env.COMPANION_APP == "openebooks" ? "openebooks" : "simplye";
+
 export const SHORTEN_URLS = !(process.env.SHORTEN_URLS === "false");
 export const REGISTRY_BASE = process.env.REGISTRY_BASE;
 export const CIRCULATION_MANAGER_BASE = process.env.SIMPLIFIED_CATALOG_BASE;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -2,6 +2,10 @@
 /**
  * Simply exporting processed env vars
  */
+
+export const COMPANION_APP =
+  process.env.COMPANION_APP === "openebooks" ? "openebooks" : "simplye";
+export const SHOW_SIMPLYE_BRANDING = COMPANION_APP === "simplye";
 export const SHORTEN_URLS = !(process.env.SHORTEN_URLS === "false");
 export const REGISTRY_BASE = process.env.REGISTRY_BASE;
 export const CIRCULATION_MANAGER_BASE = process.env.SIMPLIFIED_CATALOG_BASE;


### PR DESCRIPTION


Currently in circulation-patron-web the default branding logic sprinkles Simply-E references throughout the app. This branding should be controlled by an environment variable of the type companion-app = "simplye" | "openebooks".

Requirements (to be confirmed)

When environment variable is "simplye"

 -   Footer (display references to download SimplyE)

When environment variable is "openebooks"

-    Footer (remove eferences to download SimplyE)

