### PR TITLE
toggle SimplyE sidebar depending on COMPANION_APP

### DIFF
--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -8,6 +8,7 @@ import * as complaintActions from "../../../hooks/useComplaints/actions";
 import { RecommendationsStateContext } from "../../context/RecommendationsContext";
 import userEvent from "@testing-library/user-event";
 import ReportProblem from "../ReportProblem";
+import * as env from "../../../utils/env";
 
 const mockSetCollectionAndBook = jest.fn().mockResolvedValue({});
 
@@ -125,7 +126,29 @@ describe("book details page", () => {
     expect(utils.getByRole("button", { name: "Borrow" })).toBeInTheDocument();
   });
 
-  test("shows simplyE callout", async () => {
+  test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {
+    (env.NEXT_PUBLIC_COMPANION_APP as string) = "openebooks";
+    const utils = render(
+      <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
+      {
+        initialState: makeStateWithBook()
+      }
+    );
+
+    expect(
+      utils.queryByText("Read Now. Read Everywhere.")
+    ).not.toBeInTheDocument();
+
+    expect(utils.queryByText("SimplyE Logo")).not.toBeInTheDocument();
+    expect(
+      utils.queryByText(
+        "Browse and read our collection of eBooks and Audiobooks right from your phone."
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'simplye'", async () => {
+    (env.NEXT_PUBLIC_COMPANION_APP as string) = "simplye";
     const utils = render(
       <BookDetails setCollectionAndBook={mockSetCollectionAndBook} />,
       {

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -28,6 +28,8 @@ import SimplyELogo from "components/SimplyELogo";
 import IosBadge from "components/storeBadges/IosBadge";
 import GooglePlayBadge from "components/storeBadges/GooglePlayBadge";
 
+import { NEXT_PUBLIC_COMPANION_APP } from "../../utils/env";
+
 export const BookDetails: React.FC<{
   setCollectionAndBook: SetCollectionAndBook;
 }> = ({ setCollectionAndBook }) => {
@@ -59,7 +61,10 @@ export const BookDetails: React.FC<{
         >
           <div sx={{ flex: ["1 1 auto", 0.33], mr: [0, 4], mb: [3, 0] }}>
             <BookCover book={book} sx={{ maxWidth: [180, "initial"] }} />
-            <SimplyECallout sx={{ display: ["none", "block"] }} />
+
+            {NEXT_PUBLIC_COMPANION_APP === "simplye" && (
+              <SimplyECallout sx={{ display: ["none", "block"] }} />
+            )}
           </div>
           <div
             sx={{


### PR DESCRIPTION
Currently in circulation-patron-web the default branding logic sprinkles Simply-E references throughout the app. This branding should now be controlled by an environment variable of the type companion-app = "simplye" | "openebooks"/

For now I am just not showing the SimplyE sidebar when the COMPANION_APP is set to openebooks

NEXT_PUBLIC_COMPANION_APP=simplye or omitted 
<img width="1440" alt="Screen Shot 2020-07-27 at 6 12 42 PM" src="https://user-images.githubusercontent.com/6998954/88597250-d7770600-d034-11ea-94b0-fc3b33a8108f.png">
<hr><hr>
<hr><hr>
NEXT_PUBLIC_COMPANION_APP=openebooks
<img width="1237" alt="Screen Shot 2020-07-27 at 6 11 45 PM" src="https://user-images.githubusercontent.com/6998954/88597252-d8a83300-d034-11ea-9a2b-e7b7c7ba80dd.png">
