### PR TITLE
update image fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+## UNRELEASED CHANGES
+
+- Fix: Make BookCover show a better image fallback on image load failure. Also show medium icon on load, and fade image in once it is done loading.
+
 ## 2.2.1
 
 - Fix: Only show download options for open-access books once they have been borrowed and are present in a user's loans. Download options should still be shown for open-access books in libraries that do not have any auth enabled.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3224,9 +3224,9 @@
       "integrity": "sha512-N2bn3fU+N26Pkf+c7ZaG04T9FrDUeGtIBaJ/NGygm9GMrIkCU/6nkeWNboaAiHvji8UooqhLf1Yesf4BJLzHOA=="
     },
     "@nypl/design-system-react-components": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.6.2.tgz",
-      "integrity": "sha512-sXfbZVDq5OM4SiHWdxGWlMVxRMM3h2uRQi+v4dIDplhgO6uU09sMNZHoyUY56FQZun8ALE+ZBBtbqZfvVzx5Iw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.7.2.tgz",
+      "integrity": "sha512-3nJgUG4BZfBsvQ3Z7CMqhAAuJb76tqGXl3JcVtCoNJyKIrOGtRUnwhzPfGNUIRmfT5GKoh4Dam5ye2qSeMJ17A==",
       "requires": {
         "he": "^1.2.0",
         "react": "^16.13.1",
@@ -12075,17 +12075,17 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
-          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@csstools/normalize.css": "^10.1.0",
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
-    "@nypl/design-system-react-components": "^0.6.2",
+    "@nypl/design-system-react-components": "^0.7.2",
     "@theme-ui/color": "^0.3.1",
     "@theme-ui/components": "^0.3.1",
     "@theme-ui/match-media": "^0.3.1",

--- a/src/components/BookCover.tsx
+++ b/src/components/BookCover.tsx
@@ -2,53 +2,69 @@
 import { jsx } from "theme-ui";
 import * as React from "react";
 import { BookData } from "opds-web-client/lib/interfaces";
-import { AspectImage } from "@theme-ui/components";
-
+import { AspectRatio } from "@theme-ui/components";
+import { MediumIcon } from "./MediumIndicator";
 /**
  * This is meant to be a book cover. Primarily the image and styling,
  * along with possibly extending it to lazy load the images in the future.
  */
 
+type ImageLoadState = "loading" | "error" | "success";
+
 const BookCover: React.FC<{ book: BookData; className?: string }> = ({
   book,
   className
 }) => {
+  const [state, setState] = React.useState<ImageLoadState>("loading");
   const { imageUrl } = book;
+
+  const handleError = () => setState("error");
+  const handleLoad = () => setState("success");
+
   return (
     <div
       className={className}
       sx={{
-        borderRadius: 3,
-        backgroundColor: "ui.gray.extraLight",
         overflow: "hidden",
-        position: "relative"
+        position: "relative",
+        "&>div": {
+          height: "100%"
+        }
       }}
       aria-label={`Cover of book: ${book.title}`}
       role="img"
     >
-      <AspectImage
+      <AspectRatio
         ratio={2 / 3}
+        sx={{
+          width: "100%",
+          height: "100%",
+          p: 1,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "ui.gray.lightWarm"
+        }}
+      >
+        <MediumIcon book={book} sx={{ height: "30%", fill: "ui.gray.dark" }} />
+      </AspectRatio>
+      <img
         alt={`Cover of book: ${book.title}`}
         src={imageUrl}
+        onError={handleError}
+        onLoad={handleLoad}
         sx={{
+          width: "100%",
+          height: "100%",
+          objectFit: "contain",
           position: "absolute",
           top: 0,
           left: 0,
-          width: "100%",
-          height: "100%",
-          "::before": {
-            backgroundColor: "ui.gray.extraLight",
-            content: '"Book cover image failed to load."',
-            p: 1,
-            position: "absolute",
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            top: 0,
-            left: 0,
-            height: "100%",
-            width: "100%"
-          }
+          right: 0,
+          bottom: 0,
+          opacity: state === "success" ? 1 : 0,
+          transition: "all 0.1s ease-in"
         }}
       />
     </div>

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -18,6 +18,7 @@ import * as DS from "@nypl/design-system-react-components";
 import MediumIndicator from "components/MediumIndicator";
 import { ArrowForward } from "icons";
 import useIsBorrowed from "hooks/useIsBorrowed";
+import BookCover from "./BookCover";
 
 /**
  * In a collection you can:
@@ -73,7 +74,17 @@ export const BookListItem: React.FC<{ book: BookData }> = ({ book }) => {
     >
       <DS.Card
         sx={{ bg: "ui.white" }}
-        image={<DS.Image src={book.imageUrl ?? ""} isDecorative />}
+        image={
+          <BookCover
+            book={book}
+            sx={{
+              height: "100%",
+              width: "100%",
+              maxHeight: "100%",
+              maxWidth: "100%"
+            }}
+          />
+        }
         ctas={
           <div
             sx={{

--- a/src/css-overrides.css
+++ b/src/css-overrides.css
@@ -1,0 +1,4 @@
+/* this is to fix a problem in NYPL Design System setting global svg styles */
+svg {
+  width: initial;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,6 +28,7 @@ import enableAxe from "utils/axe";
 import "system-font-css";
 import { Config } from "dataflow/LibraryDataCache";
 import "@nypl/design-system-react-components/dist/styles.css";
+import "css-overrides.css";
 
 type NotFoundProps = {
   statusCode: number;


### PR DESCRIPTION
This PR updates the BookCover component so that it shows the medium icon while the image is loading and keeps it there in the case of an error. When the book finishes loading we now fade it in to view. 

