### PR TITLE
Fetch loans only on app startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## CHANGELOG
 
 # 2.3.0
+
 - Feature: Add support for SAML auth providers.
 - Feature: Add `NEXT_PUBLIC_COMPANION_APP` env var (in PR #97) to toggle the display of SimplyE branding. Value can be either `"simplye"` or `"openebooks"`. 
 - Fix: Don't show search bar if collection does not include search data.
 - Fix: Fetch loans on page load when auth credentials are detected so that if you navigate directly to a book you have checked out, it will properly show checked out state.
 - Fix: Make BookCover show a better image fallback on image load failure. Also show medium icon on load, and fade image in once it is done loading.
+- Fix: Only fetch loans on app start, instead updating our internal store whenever we perform a successful mutation like borrowing a book.
 
 ## 2.2.1
 

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -9,6 +9,8 @@ import ClientOnly from "./ClientOnly";
 import { H2 } from "./Text";
 import Select from "./Select";
 import FormLabel from "./form/FormLabel";
+import { useActions } from "opds-web-client/lib/components/context/ActionsContext";
+import useTypedSelector from "hooks/useTypedSelector";
 
 /**
  *  - makes sure auth state is loaded from cookies
@@ -20,6 +22,23 @@ const Auth: React.FC = ({ children }) => {
   const dialog = useDialogState();
   const library = useLibraryContext();
   const [authProvider, setAuthProvider] = React.useState(providers?.[0]);
+  const { fetcher, actions, dispatch } = useActions();
+
+  /**
+   * This component is responsible for fetching loans whenever the
+   * auth credentials change
+   */
+  const { provider: currentProvider, credentials } =
+    fetcher.getAuthCredentials() ?? {};
+  const loansUrl = useTypedSelector(state => state.loans.url);
+  React.useEffect(() => {
+    if (currentProvider && credentials) {
+      dispatch(
+        actions.saveAuthCredentials({ provider: currentProvider, credentials })
+      );
+      if (loansUrl) dispatch(actions.fetchLoans(loansUrl));
+    }
+  }, [currentProvider, credentials, loansUrl, actions, dispatch]);
 
   // the providers get set when the form is shown, so
   // it's initially undefined. We need to update when they get set

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -36,7 +36,6 @@ const Auth: React.FC = ({ children }) => {
       dispatch(
         actions.saveAuthCredentials({ provider: currentProvider, credentials })
       );
-      console.log("got here", loansUrl);
       if (loansUrl) dispatch(actions.fetchLoans(loansUrl));
     }
   }, [currentProvider, credentials, loansUrl, actions, dispatch]);

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -36,6 +36,7 @@ const Auth: React.FC = ({ children }) => {
       dispatch(
         actions.saveAuthCredentials({ provider: currentProvider, credentials })
       );
+      console.log("got here", loansUrl);
       if (loansUrl) dispatch(actions.fetchLoans(loansUrl));
     }
   }, [currentProvider, credentials, loansUrl, actions, dispatch]);

--- a/src/components/__tests__/Auth.test.tsx
+++ b/src/components/__tests__/Auth.test.tsx
@@ -9,7 +9,11 @@ import { AuthCredentials } from "opds-web-client/lib/interfaces";
 import userEvent from "@testing-library/user-event";
 
 const stateWithAuth: State = merge<State>(fixtures.initialState, {
-  auth: fixtures.unauthenticatedAuthState
+  auth: fixtures.unauthenticatedAuthState,
+  loans: {
+    url: "/loans-url",
+    books: []
+  }
 });
 
 afterEach(() => {
@@ -212,7 +216,5 @@ test("attempts to save auth credentials", async () => {
   expect(setCredentialsSpy).toHaveBeenCalledTimes(1);
   expect(setCredentialsSpy).toHaveBeenCalledWith(credentials);
   expect(fetchLoansSpy).toHaveBeenCalledTimes(1);
-  expect(fetchLoansSpy).toHaveBeenLastCalledWith(
-    "http://test-cm.com/catalogUrl/loans"
-  );
+  expect(fetchLoansSpy).toHaveBeenLastCalledWith("/loans-url");
 });

--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -82,7 +82,7 @@ describe("available to borrow book", () => {
     ).toBeInTheDocument();
   });
 
-  test("shows loading state when borrowing, borrows, and refetches loans", async () => {
+  test("shows loading state when borrowing, borrows, and doesn't refetch loans", async () => {
     // mock the actions.updateBook
     const updateBookSpy = jest
       .spyOn(actions, "updateBook")
@@ -112,8 +112,8 @@ describe("available to borrow book", () => {
     });
     expect(borrowButton).toBeInTheDocument();
     expect(borrowButton).toHaveAttribute("disabled", "");
-    // we should refetch the loans after borrowing
-    await waitFor(() => expect(fetchLoansSpy).toHaveBeenCalledTimes(1));
+    // we only fetch loans on app start
+    expect(fetchLoansSpy).toHaveBeenCalledTimes(0);
   });
 
   test("displays error message", () => {
@@ -156,7 +156,7 @@ describe("ready to borrow book", () => {
     ).toBeInTheDocument();
   });
 
-  test("shows loading state when borrowing, borrows, and refetches loans", async () => {
+  test("shows loading state when borrowing, borrows, and doesn't refetch loans", async () => {
     // mock the actions.updateBook
     const updateBookSpy = jest
       .spyOn(actions, "updateBook")
@@ -186,8 +186,7 @@ describe("ready to borrow book", () => {
     });
     expect(borrowButton).toBeInTheDocument();
     expect(borrowButton).toHaveAttribute("disabled", "");
-    // we should refetch the loans after borrowing
-    await waitFor(() => expect(fetchLoansSpy).toHaveBeenCalledTimes(1));
+    expect(fetchLoansSpy).toHaveBeenCalledTimes(0);
   });
 
   test("displays error message", () => {
@@ -238,7 +237,7 @@ describe("available to reserve book", () => {
     expect(reserveButton).toBeInTheDocument();
   });
 
-  test("shows loading state when reserving, reserves, and refetches loans", async () => {
+  test("shows loading state when reserving, reserves, and doesn't refetch loans", async () => {
     // mock the actions.updateBook
     const updateBookSpy = jest
       .spyOn(actions, "updateBook")
@@ -268,8 +267,7 @@ describe("available to reserve book", () => {
     });
     expect(reserveButton).toBeInTheDocument();
     expect(reserveButton).toHaveAttribute("disabled", "");
-    // we should refetch the loans after borrowing
-    await waitFor(() => expect(fetchLoansSpy).toHaveBeenCalledTimes(1));
+    expect(fetchLoansSpy).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, fixtures, actions, waitFor } from "test-utils";
+import { render, fixtures, actions } from "test-utils";
 import merge from "deepmerge";
 import { BookListItem } from "components/BookList";
 import { State } from "opds-web-client/lib/state";

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -3,7 +3,6 @@ import {
   render,
   fixtures,
   actions,
-  waitFor,
   waitForElementToBeRemoved
 } from "test-utils";
 import { mergeBook } from "test-utils/fixtures";

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -163,7 +163,7 @@ describe("available to borrow", () => {
     expect(borrowButton).toHaveAttribute("disabled", "");
   });
 
-  test("calls fetch loans after borrowing", async () => {
+  test("doesn't refetch loans after borrowing", async () => {
     const fetchLoansSpy = jest.spyOn(actions, "fetchLoans");
     const _updateBookSpy = jest
       .spyOn(actions, "updateBook")
@@ -182,7 +182,7 @@ describe("available to borrow", () => {
     userEvent.click(utils.getByText("Borrow"));
 
     await waitForElementToBeRemoved(() => utils.getByText("Borrowing..."));
-    await waitFor(() => expect(fetchLoansSpy).toHaveBeenCalledTimes(1));
+    expect(fetchLoansSpy).toHaveBeenCalledTimes(0);
   });
 
   test("displays error message", () => {
@@ -268,7 +268,7 @@ describe("ready to borrow", () => {
     expect(borrowButton).toHaveAttribute("disabled", "");
   });
 
-  test("refetches loans after borrowing", async () => {
+  test("doesn't refetch loans after borrowing", async () => {
     const fetchLoansSpy = jest.spyOn(actions, "fetchLoans");
     const _updateBookSpy = jest
       .spyOn(actions, "updateBook")
@@ -286,7 +286,7 @@ describe("ready to borrow", () => {
     userEvent.click(utils.getByText("Borrow"));
     // the borrow button should be gone now
     await waitForElementToBeRemoved(() => utils.getByText("Borrowing..."));
-    await waitFor(() => expect(fetchLoansSpy).toHaveBeenCalledTimes(1));
+    expect(fetchLoansSpy).toHaveBeenCalledTimes(0);
   });
 
   test("displays error message", () => {
@@ -415,7 +415,7 @@ describe("available to reserve", () => {
     expect(reserveButton).toBeInTheDocument();
     expect(reserveButton).toHaveAttribute("disabled", "");
   });
-  test("refetches loans after reserving", async () => {
+  test("doesn't refetch loans after reserving", async () => {
     const fetchLoansSpy = jest.spyOn(actions, "fetchLoans");
     const _updateBookSpy = jest
       .spyOn(actions, "updateBook")
@@ -431,7 +431,7 @@ describe("available to reserve", () => {
       })
     });
     userEvent.click(utils.getByText("Reserve"));
-    await waitFor(() => expect(fetchLoansSpy).toHaveBeenCalledTimes(1));
+    expect(fetchLoansSpy).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/src/components/context/ContextProvider.tsx
+++ b/src/components/context/ContextProvider.tsx
@@ -40,8 +40,14 @@ const AppContextProvider: React.FC<ProviderProps> = ({
   const libraryId = library.id;
   const urlShortener = new UrlShortener(library.catalogUrl, shortenUrls);
   const pathFor: PathFor = getPathFor(urlShortener, libraryId);
-  const computedFetcher = fetcher ?? new DataFetcher({ adapter });
-  const computedActions = actions ?? new ActionsCreator(computedFetcher);
+  const computedFetcher = React.useMemo(
+    () => fetcher ?? new DataFetcher({ adapter }),
+    [fetcher]
+  );
+  const computedActions = React.useMemo(
+    () => actions ?? new ActionsCreator(computedFetcher),
+    [actions, computedFetcher]
+  );
 
   return (
     <ReakitProvider>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -14,8 +14,8 @@ function useAuth() {
   const router = useRouter();
   const authState = useTypedSelector(state => state.auth);
   const isSignedIn = !!authState?.credentials;
-  const { fetcher, actions, dispatch } = useActions();
-  const { buildMultiLibraryLink, urlShortener } = useLinkUtils();
+  const { actions, dispatch } = useActions();
+  const { buildMultiLibraryLink } = useLinkUtils();
   const signOut = () => dispatch(actions.clearAuthCredentials());
   const signOutAndGoHome = () => {
     signOut();
@@ -23,27 +23,10 @@ function useAuth() {
     router.push(link.href, link.as);
   };
 
-  const loansUrl = decodeURIComponent(
-    urlShortener.expandCollectionUrl("loans")
-  );
-  const signIn = () => dispatch(actions.fetchLoans(loansUrl));
-  /**
-   * On mount, we need to check for auth data in cookies. This used
-   * to be done in componentWillMount of Root in OPDS.
-   *
-   * @TODO we need to change this so that it's loading using lookForCredentials
-   */
-  React.useEffect(() => {
-    // get the credentials
-    const credentials = fetcher.getAuthCredentials();
-    // save the credentials if they exist
-    if (credentials) {
-      dispatch(actions.saveAuthCredentials(credentials));
-      dispatch(actions.fetchLoans(loansUrl));
-    }
-  }, [dispatch, actions, fetcher, loansUrl]);
+  const loansUrl = useTypedSelector(state => state.loans.url);
+  const signIn = () => loansUrl && dispatch(actions.fetchLoans(loansUrl));
 
-  /**
+  /*
    * We need to set SAML credentials whenenever they are available in a
    * query param
    */

--- a/src/hooks/useBorrow.ts
+++ b/src/hooks/useBorrow.ts
@@ -10,7 +10,6 @@ export default function useBorrow(book: BookData) {
   const bookError = useTypedSelector(state => state.book?.error);
   const errorMsg = getErrorMsg(bookError);
   const { actions, dispatch } = useActions();
-  const loansUrl = useTypedSelector(state => state.loans.url);
 
   const borrowOrReserve = async () => {
     if (book.borrowUrl) {
@@ -19,10 +18,6 @@ export default function useBorrow(book: BookData) {
       if (!isUnmounted.current) setLoading(false);
     } else {
       throw Error("No borrow url present for book");
-    }
-    // refetch the loans
-    if (loansUrl) {
-      await dispatch(actions.fetchLoans(loansUrl));
     }
   };
 

--- a/src/hooks/useEffectDebugger.ts
+++ b/src/hooks/useEffectDebugger.ts
@@ -1,3 +1,4 @@
+import { IS_DEVELOPMENT } from "./../utils/env";
 import * as React from "react";
 
 const usePrevious = (value, initialValue) => {
@@ -9,6 +10,11 @@ const usePrevious = (value, initialValue) => {
 };
 
 const useEffectDebugger = (effectHook, dependencies, dependencyNames = []) => {
+  if (!IS_DEVELOPMENT)
+    throw new Error(
+      "useEffectDebugger only to be used in development. Please revert to using React.useEffect."
+    );
+
   const previousDeps = usePrevious(dependencies, []);
 
   const changedDeps = dependencies.reduce((accum, dependency, index) => {
@@ -30,6 +36,8 @@ const useEffectDebugger = (effectHook, dependencies, dependencyNames = []) => {
     console.log("[use-effect-debugger] ", changedDeps);
   }
 
+  // ignore the react hook warning bc this is only to be used in development
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   React.useEffect(effectHook, dependencies);
 };
 

--- a/src/hooks/useEffectDebugger.ts
+++ b/src/hooks/useEffectDebugger.ts
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+const usePrevious = (value, initialValue) => {
+  const ref = React.useRef(initialValue);
+  React.useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+const useEffectDebugger = (effectHook, dependencies, dependencyNames = []) => {
+  const previousDeps = usePrevious(dependencies, []);
+
+  const changedDeps = dependencies.reduce((accum, dependency, index) => {
+    if (dependency !== previousDeps[index]) {
+      const keyName = dependencyNames[index] || index;
+      return {
+        ...accum,
+        [keyName]: {
+          before: previousDeps[index],
+          after: dependency
+        }
+      };
+    }
+
+    return accum;
+  }, {});
+
+  if (Object.keys(changedDeps).length) {
+    console.log("[use-effect-debugger] ", changedDeps);
+  }
+
+  React.useEffect(effectHook, dependencies);
+};
+
+export default useEffectDebugger;

--- a/src/hooks/useSetCollectionAndBook.ts
+++ b/src/hooks/useSetCollectionAndBook.ts
@@ -1,7 +1,5 @@
 import * as React from "react";
 import { SetCollectionAndBook } from "../interfaces";
-import { useActions } from "opds-web-client/lib/components/context/ActionsContext";
-import useAuth from "./useAuth";
 import { useRouter } from "next/router";
 import useLinkUtils from "../components/context/LinkUtilsContext";
 
@@ -18,25 +16,15 @@ const useSetCollectionAndBook = (
 ) => {
   const { bookUrl, collectionUrl } = useRouter().query;
   const finalCollectionUrl = collectionUrlOverride ?? collectionUrl;
-  const { actions, dispatch } = useActions();
-  const { isSignedIn } = useAuth();
   const { urlShortener } = useLinkUtils();
 
   const fullCollectionUrl = decodeURIComponent(
     urlShortener.expandCollectionUrl(finalCollectionUrl)
   );
   const fullBookUrl = urlShortener.expandBookUrl(bookUrl);
-  // set the collection and book whenever the urls change, and fetch loans
+  // set the collection and book whenever the urls change
   React.useEffect(() => {
-    setCollectionAndBook(fullCollectionUrl, fullBookUrl).then(
-      ({ collectionData }) => {
-        // then fetch the loans (like in OPDS root)
-        // but only if you are already signed in. Otherwise you don't need them at this point
-        if (collectionData?.shelfUrl && isSignedIn) {
-          dispatch(actions.fetchLoans(collectionData.shelfUrl));
-        }
-      }
-    );
+    setCollectionAndBook(fullCollectionUrl, fullBookUrl);
     /**
      * We will explicitly not have exhaustive deps here because
      * setCollectionAndBook changes identity on every render, which


### PR DESCRIPTION
This resolves a bug in CPW caused by the 30 minute cache of loans data instituted by the server. Previously, we refetched the loans data quite often (relying on the browser cache to avoid network requests). This meant that after borrowing a book, we would then fetch loans and get stale information. To rectify this, OWC is set up to modify the redux loans state with the return value of a borrow request. 

What I've done here is to mimic the mobile apps, and only fetch loans once when the app starts, and then we simply maintain our internal state from there on out. This means we can become out of sync with the server, but will become eventually consistent (after the 30 minute cache expires). 

This PR also updates the url we fetch for loans from a manually created one to the one present in `state.loans.url`. This should resolve an issue I saw being discussed on slack @M0nica @leonardr . 