### PR TITLE
Filter platform incompatible links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: Don't show search bar if collection does not include search data.
 - Fix: Fetch loans on page load when auth credentials are detected so that if you navigate directly to a book you have checked out, it will properly show checked out state.
 - Fix: Make BookCover show a better image fallback on image load failure. Also show medium icon on load, and fade image in once it is done loading.
+- Fix: Don't show mac users ACSM files for download as they cannot read them on their computer.
 
 ## 2.2.1
 

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -6,7 +6,8 @@ import {
   dedupeLinks,
   availabilityString,
   queueString,
-  bookIsAudiobook
+  bookIsAudiobook,
+  filterPlatformIncompatibleLinks
 } from "utils/book";
 import {
   BookData,
@@ -237,7 +238,9 @@ const DownloadCard: React.FC<{
   subtitle: string;
 }> = ({ book, links, subtitle }) => {
   const { title } = book;
-  const dedupedLinks = dedupeLinks(links ?? []);
+  const filteredLinks = filterPlatformIncompatibleLinks(
+    dedupeLinks(links ?? [])
+  );
   const isAudiobook = bookIsAudiobook(book);
 
   return (
@@ -251,13 +254,13 @@ const DownloadCard: React.FC<{
           <Text>{subtitle}</Text>
         </Stack>
       </Stack>
-      {!isAudiobook && (
+      {!isAudiobook && filteredLinks.length > 0 && (
         <Stack direction="column" sx={{ mt: 3 }}>
           <Text variant="text.body.italic" sx={{ textAlign: "center" }}>
             If you would rather read on your computer, you can:
           </Text>
           <Stack sx={{ justifyContent: "center", flexWrap: "wrap" }}>
-            {dedupedLinks.map(link => (
+            {filteredLinks.map(link => (
               <DownloadButton key={link.url} link={link} title={title} />
             ))}
           </Stack>
@@ -271,12 +274,7 @@ const DownloadButton: React.FC<{
   link: FulfillmentLink | MediaLink;
   title: string;
 }> = ({ link, title }) => {
-  const { fulfill, downloadLabel, isPlatformCompatible } = useDownloadButton(
-    link,
-    title
-  );
-
-  if (!isPlatformCompatible) return null;
+  const { fulfill, downloadLabel } = useDownloadButton(link, title);
   return (
     <Button
       onClick={fulfill}

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -271,7 +271,12 @@ const DownloadButton: React.FC<{
   link: FulfillmentLink | MediaLink;
   title: string;
 }> = ({ link, title }) => {
-  const { fulfill, downloadLabel } = useDownloadButton(link, title);
+  const { fulfill, downloadLabel, isPlatformCompatible } = useDownloadButton(
+    link,
+    title
+  );
+
+  if (!isPlatformCompatible) return null;
   return (
     <Button
       onClick={fulfill}

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -242,7 +242,7 @@ const DownloadCard: React.FC<{
     dedupeLinks(links ?? [])
   );
   const isAudiobook = bookIsAudiobook(book);
-
+  console.log(filteredLinks);
   return (
     <>
       <Stack sx={{ alignItems: "center" }}>

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -525,6 +525,56 @@ describe("available to download", () => {
     expect(PDFButton).toBeInTheDocument();
   });
 
+  const platformGetter = jest.spyOn(window.navigator, "platform", "get");
+
+  test("doesn't show ACSM books on Mac", () => {
+    const acsmBook = mergeBook({
+      openAccessLinks: undefined,
+      fulfillmentLinks: [
+        {
+          url: "/epub-link",
+          type: "application/vnd.adobe.adept+xml",
+          indirectType: "indirect"
+        }
+      ],
+      availability: {
+        status: "available",
+        until: "2020-06-18"
+      }
+    });
+    platformGetter.mockReturnValue("MacIntel");
+    const utils = render(<FulfillmentCard book={acsmBook} />);
+
+    expect(
+      utils.queryByText(/If you would rather read on your computer, you can:/)
+    ).not.toBeInTheDocument();
+    expect(utils.queryByText(/download acsm/i)).not.toBeInTheDocument();
+  });
+
+  test("shows ACSM books on all other platforms", () => {
+    const acsmBook = mergeBook({
+      openAccessLinks: undefined,
+      fulfillmentLinks: [
+        {
+          url: "/epub-link",
+          type: "application/vnd.adobe.adept+xml",
+          indirectType: "indirect"
+        }
+      ],
+      availability: {
+        status: "available",
+        until: "2020-06-18"
+      }
+    });
+    platformGetter.mockReturnValue("Win");
+    const utils = render(<FulfillmentCard book={acsmBook} />);
+
+    expect(
+      utils.getByText(/If you would rather read on your computer, you can:/)
+    ).toBeInTheDocument();
+    expect(utils.getByText(/download acsm/i)).toBeInTheDocument();
+  });
+
   test("download button calls fulfillBook", () => {
     const fulfillBookSpy = jest.spyOn(actions, "fulfillBook");
 

--- a/src/utils/book.tsx
+++ b/src/utils/book.tsx
@@ -5,11 +5,11 @@ import {
   BookMedium,
   MediaLink
 } from "opds-web-client/lib/interfaces";
-import { isPlatoformCompatible } from "opds-web-client/lib/utils/book";
 import { BookFulfillmentState } from "interfaces";
 
 import { Book, Headset } from "../icons";
 import { getMedium } from "opds-web-client/lib/utils/book";
+import { fixMimeType } from "opds-web-client/lib/hooks/useDownloadButton";
 
 export function getAuthors(book: BookData, lim?: number): string[] {
   // select contributors if the authors array is undefined or empty.
@@ -52,6 +52,13 @@ export function dedupeLinks<T extends MediaLink>(links: T[]) {
 
     return isDup ? uniqueArr : [...uniqueArr, current];
   }, []);
+}
+
+const isMac = navigator.platform.indexOf("Mac") > -1;
+export function linkIsPlatformCompatible<T extends MediaLink>(link: T) {
+  if (isMac && fixMimeType(link.type) === "application/vnd.adobe.adept+xml")
+    return false;
+  return true;
 }
 
 export function filterPlatformIncompatibleLinks<T extends MediaLink>(

--- a/src/utils/book.tsx
+++ b/src/utils/book.tsx
@@ -10,6 +10,7 @@ import { BookFulfillmentState } from "interfaces";
 import { Book, Headset } from "../icons";
 import { getMedium } from "opds-web-client/lib/utils/book";
 import { fixMimeType } from "opds-web-client/lib/hooks/useDownloadButton";
+import { IS_SERVER } from "./env";
 
 export function getAuthors(book: BookData, lim?: number): string[] {
   // select contributors if the authors array is undefined or empty.
@@ -54,7 +55,9 @@ export function dedupeLinks<T extends MediaLink>(links: T[]) {
   }, []);
 }
 
-const isMac = navigator.platform.indexOf("Mac") > -1;
+const isMac = IS_SERVER
+  ? false
+  : navigator && navigator.platform.indexOf("Mac") > -1;
 export function linkIsPlatformCompatible<T extends MediaLink>(link: T) {
   if (isMac && fixMimeType(link.type) === "application/vnd.adobe.adept+xml")
     return false;
@@ -64,7 +67,7 @@ export function linkIsPlatformCompatible<T extends MediaLink>(link: T) {
 export function filterPlatformIncompatibleLinks<T extends MediaLink>(
   links: T[]
 ) {
-  return links.filter(isPlatoformCompatible(link.type));
+  return links.filter(linkIsPlatformCompatible);
 }
 
 function hasBorrowRelation(book: BookData) {

--- a/src/utils/book.tsx
+++ b/src/utils/book.tsx
@@ -55,10 +55,12 @@ export function dedupeLinks<T extends MediaLink>(links: T[]) {
   }, []);
 }
 
-const isMac = IS_SERVER
-  ? false
-  : navigator && navigator.platform.indexOf("Mac") > -1;
 export function linkIsPlatformCompatible<T extends MediaLink>(link: T) {
+  const isMac = IS_SERVER
+    ? false
+    : window &&
+      window.navigator &&
+      window.navigator.platform.indexOf("Mac") > -1;
   if (isMac && fixMimeType(link.type) === "application/vnd.adobe.adept+xml")
     return false;
   return true;

--- a/src/utils/book.tsx
+++ b/src/utils/book.tsx
@@ -5,6 +5,7 @@ import {
   BookMedium,
   MediaLink
 } from "opds-web-client/lib/interfaces";
+import { isPlatoformCompatible } from "opds-web-client/lib/utils/book";
 import { BookFulfillmentState } from "interfaces";
 
 import { Book, Headset } from "../icons";
@@ -51,6 +52,12 @@ export function dedupeLinks<T extends MediaLink>(links: T[]) {
 
     return isDup ? uniqueArr : [...uniqueArr, current];
   }, []);
+}
+
+export function filterPlatformIncompatibleLinks<T extends MediaLink>(
+  links: T[]
+) {
+  return links.filter(isPlatoformCompatible(link.type));
 }
 
 function hasBorrowRelation(book: BookData) {


### PR DESCRIPTION
This PR filters download links to only show ones that are platform compatible. Currently the only check we are performing is to not show ACSM files for mac users, as there is no way to read them on mac.