### PR TITLE
update signIn to showAuth form when "Sign In" is clicked

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -27,21 +27,22 @@ function useAuth() {
     return state.loans.url;
   });
 
-  const authTitle = useTypedSelector(state => state.auth.title) || "";
+  const auth = useTypedSelector(state => state.auth);
 
   const noop = () => ({});
 
-  const authCallback = useTypedSelector(state => state.auth.callback) || noop;
-
-  const authCancel = useTypedSelector(state => state.auth.cancel) || noop;
-
-  const authProviders = useTypedSelector(state => state.auth.providers) || [];
+  const { title, callback, cancel, providers } = auth;
 
   const signIn = () =>
     loansUrl &&
-    authProviders &&
+    providers &&
     dispatch(
-      actions.showAuthForm(authCallback, authCancel, authProviders, authTitle)
+      actions.showAuthForm(
+        callback || noop,
+        cancel || noop,
+        providers,
+        title || ""
+      )
     ) &&
     dispatch(actions.fetchLoans(loansUrl));
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -23,8 +23,27 @@ function useAuth() {
     router.push(link.href, link.as);
   };
 
-  const loansUrl = useTypedSelector(state => state.loans.url);
-  const signIn = () => loansUrl && dispatch(actions.fetchLoans(loansUrl));
+  const loansUrl = useTypedSelector(state => {
+    return state.loans.url;
+  });
+
+  const authTitle = useTypedSelector(state => state.auth.title) || "";
+
+  const noop = () => ({});
+
+  const authCallback = useTypedSelector(state => state.auth.callback) || noop;
+
+  const authCancel = useTypedSelector(state => state.auth.cancel) || noop;
+
+  const authProviders = useTypedSelector(state => state.auth.providers) || [];
+
+  const signIn = () =>
+    loansUrl &&
+    authProviders &&
+    dispatch(
+      actions.showAuthForm(authCallback, authCancel, authProviders, authTitle)
+    ) &&
+    dispatch(actions.fetchLoans(loansUrl));
 
   /*
    * We need to set SAML credentials whenenever they are available in a


### PR DESCRIPTION
This is an attempt to resolve issue where "log in" button in the navigation seemed to be working when logging in for the first time but was not functional after logging out when attempting to log back in again.

1. Run circulation-patron-web locally with SIMPLIFIED_CATALOG_BASE=http://qa.circulation.openebooks.us/USOEI/groups/ SHORTEN_URLS=false npm run dev
2. Go to index page: http://localhost:3000/
3. Click on log in the navigation
4. Login Modal appears and Log in using First Book credentials
5. Log Out
6. Click Log in in navigation


Expected: Login modal appears and allow First Book or Clever credentials.
Actual: Nothing happens


Note: Currently if you attempt to check out a book on the book details page then you are prompted to login which supports First Book login. The nav login seems to be working when logging in for the first time but not after logging out and then attempting to log back in again.