### PR TITLE
display different copy for fullfillment card in OpenEBooks context

### DIFF
--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -23,6 +23,7 @@ import { MediumIcon } from "components/MediumIndicator";
 import SvgDownload from "icons/Download";
 import SvgPhone from "icons/Phone";
 import useIsBorrowed from "hooks/useIsBorrowed";
+import { NEXT_PUBLIC_COMPANION_APP } from "../../utils/env";
 
 const FulfillmentCard: React.FC<{ book: BookData }> = ({ book }) => {
   return (
@@ -240,13 +241,16 @@ const DownloadCard: React.FC<{
   const dedupedLinks = dedupeLinks(links ?? []);
   const isAudiobook = bookIsAudiobook(book);
 
+  const companionApp =
+    NEXT_PUBLIC_COMPANION_APP === "openebooks" ? "Open eBooks" : "SimplyE";
+
   return (
     <>
       <Stack sx={{ alignItems: "center" }}>
         <SvgPhone sx={{ fontSize: 64 }} />
         <Stack direction="column">
           <Text variant="text.callouts.bold">
-            You&apos;re ready to read this book in SimplyE!
+            You&apos;re ready to read this book in {companionApp}!
           </Text>
           <Text>{subtitle}</Text>
         </Stack>

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -14,6 +14,8 @@ import { State } from "opds-web-client/lib/state";
 import * as useBorrow from "hooks/useBorrow";
 import _download from "opds-web-client/lib/components/download";
 
+import * as env from "../../../utils/env";
+
 jest.mock("opds-web-client/lib/components/download");
 window.open = jest.fn();
 
@@ -500,6 +502,17 @@ describe("available to download", () => {
       utils.getByText("You have this book on loan until Thu Jun 18 2020.")
     ).toBeInTheDocument();
     expect(utils.getByText("You're ready to read this book in SimplyE!"));
+  });
+
+  test("correct title and subtitle when COMPANION_APP is set to openebooks", () => {
+    (env.NEXT_PUBLIC_COMPANION_APP as string) = "openebooks";
+    const utils = render(<FulfillmentCard book={downloadableBook} />);
+    expect(
+      utils.getByText("You have this book on loan until Thu Jun 18 2020.")
+    ).toBeInTheDocument();
+    expect(
+      utils.getByText("You're ready to read this book in Open eBooks!")
+    ).toBeInTheDocument();
   });
 
   test("handles lack of availability info", () => {

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -476,6 +476,8 @@ describe("reserved", () => {
 });
 
 describe("available to download", () => {
+  beforeEach(() => ((env.NEXT_PUBLIC_COMPANION_APP as string) = "simplye"));
+
   const downloadableBook = mergeBook({
     openAccessLinks: undefined,
     fulfillmentLinks: [


### PR DESCRIPTION
Currently in circulation-patron-web the default branding logic sprinkles Simply-E references throughout the app. Now this branding is controlled by an environment variable of the type  companion-app = "simplye" | "openebooks".

Requirements
When the environment variable is set to "openebooks" the Fulfillment Card changes from “You’re ready to read this book in SimplyE” to “You’re ready to read this book in Open eBooks”

When env variable is NOT set to "openebooks" continue displaying SimplyE verbiage