### PR TITLE
Add npm run dev:https

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you are using a Library Registry, this configuration will automatically be cr
 Once the dependencies are installed and application environments configured, the following two base commands can be used to start the application:
 
 - `npm run dev` - This command will start the development server, which builds pages lazily (when you request them) to shorten the startup time.
+- `npm run dev:https` - This will run the app in development with https enabled. This uses the `dev-server.js` script to load https keys. It's useful when developing features that require https to be enabled.
 - `npm run build` - This will build both the server and the client code into `./next`. You can then run `npm run start` to start the server.
 
 The application will start at the base URL of `localhost:3000`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "scripts": {
-    "dev": "node dev-server.js",
+    "dev": "next dev",
+    "dev:https": "node dev-server.js",
     "dev:axe": "REACT_AXE=true npm run dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
This is a very simply PR not really worthy of a version or changelog. It simply adds a new npm script to run the app with https. The default `npm run dev` will run it over http, and `npm run dev:https` will run it over https with the `dev-server.js` script. 