### PR TITLE
update React aXe configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,9 @@ const config = {
     // Perform customizations to webpack config
     // Important: return the modified config
     !isServer && config.plugins.push(new webpack.IgnorePlugin(/jsdom$/));
+    // react-axe should only be bundled when REACT_AXE=true
+    !process.env.REACT_AXE &&
+      config.plugins.push(new webpack.IgnorePlugin(/react-axe$/));
     // Fixes dependency on "fs" module.
     // we don't (and can't) depend on this in client-side code.
     if (!isServer) {

--- a/src/utils/axe.ts
+++ b/src/utils/axe.ts
@@ -5,7 +5,7 @@ import * as React from "react";
  * @see https://github.com/dequelabs/react-axe
  */
 export default async function enableAxe() {
-  const ReactDOM = await import("react-dom");
-  const axe = await import("react-axe");
-  axe.default(React, ReactDOM, 1000);
+  const ReactDOM = require("react-dom");
+  const axe = require("react-axe");
+  axe(React, ReactDOM, 1000);
 }


### PR DESCRIPTION
- There were some type issues with React-Axe in circulation-patron-web and it needed some tweaks to be functional again. 
- In terms of testing I confirmed that I am now able to see the aXe logs when running `yarn dev:axe`