### PR TITLE
a11y: add visible focus to filled and ghost buttons

### DIFF
--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -1,9 +1,6 @@
 import { SystemStyleObject } from "@styled-system/css";
 import { darken, lightness } from "@theme-ui/color";
 import { ButtonSize, ButtonVariant } from "./index";
-import theme from "../../theme/theme";
-
-const { shadows } = theme;
 
 export const sizes = {
   sm: {},
@@ -57,7 +54,7 @@ export const styleProps = (
           textDecoration: "none"
         },
         "&:focus": {
-          boxShadow: shadows.focus
+          boxShadow: "focus"
         },
         "&:active": {
           bg: darken(color, 0.1)
@@ -84,7 +81,7 @@ export const styleProps = (
           textDecoration: "none"
         },
         "&:focus": {
-          boxShadow: shadows.focus
+          boxShadow: "focus"
         },
         "&:active": {
           // bg: darken(color, 0.1)

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -1,6 +1,9 @@
 import { SystemStyleObject } from "@styled-system/css";
 import { darken, lightness } from "@theme-ui/color";
 import { ButtonSize, ButtonVariant } from "./index";
+import theme from "../../theme/theme";
+
+const { shadows } = theme;
 
 export const sizes = {
   sm: {},
@@ -51,8 +54,10 @@ export const styleProps = (
         "&:focus,&:hover": {
           bg: darken(color, 0.05),
           color: "white",
-          textDecoration: "none",
-          boxShadow: `0 0 0 0.2em rgba(0, 109, 255, 0.4)`
+          textDecoration: "none"
+        },
+        "&:focus": {
+          boxShadow: shadows.focus
         },
         "&:active": {
           bg: darken(color, 0.1)
@@ -76,8 +81,10 @@ export const styleProps = (
         "&:focus,&:hover": {
           bg: lightness(color, 0.85),
           color: color,
-          textDecoration: "none",
-          boxShadow: `0 0 0 0.2em rgba(0, 109, 255, 0.4)`
+          textDecoration: "none"
+        },
+        "&:focus": {
+          boxShadow: shadows.focus
         },
         "&:active": {
           // bg: darken(color, 0.1)

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -51,7 +51,8 @@ export const styleProps = (
         "&:focus,&:hover": {
           bg: darken(color, 0.05),
           color: "white",
-          textDecoration: "none"
+          textDecoration: "none",
+          boxShadow: `0 0 0 0.2em rgba(0, 109, 255, 0.4)`
         },
         "&:active": {
           bg: darken(color, 0.1)
@@ -75,7 +76,8 @@ export const styleProps = (
         "&:focus,&:hover": {
           bg: lightness(color, 0.85),
           color: color,
-          textDecoration: "none"
+          textDecoration: "none",
+          boxShadow: `0 0 0 0.2em rgba(0, 109, 255, 0.4)`
         },
         "&:active": {
           // bg: darken(color, 0.1)

--- a/src/components/MyBooks.tsx
+++ b/src/components/MyBooks.tsx
@@ -10,7 +10,6 @@ import {
 } from "opds-web-client/lib/components/mergeRootProps";
 import { SetCollectionAndBook } from "../interfaces";
 import useAuth from "../hooks/useAuth";
-import Button from "./Button";
 import useTypedSelector from "../hooks/useTypedSelector";
 import { ListView } from "./BookList";
 import { PageLoader } from "./LoadingIndicator";

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -44,6 +44,9 @@ exports[`LinkButton renders correct element 1`] = `
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.emotion-0:focus {
   box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 
@@ -118,6 +121,9 @@ exports[`NavButton renders correct element 1`] = `
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.emotion-0:focus {
   box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 
@@ -183,6 +189,9 @@ exports[`variants filled (default) 1`] = `
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.emotion-0:focus {
   box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 
@@ -248,6 +257,9 @@ exports[`variants ghost 1`] = `
   color: var(--theme-ui-colors-brand-primary,#337ab7);
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.emotion-0:focus {
   box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`LinkButton renders correct element 1`] = `
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
+  box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 
 .emotion-0:active {
@@ -117,6 +118,7 @@ exports[`NavButton renders correct element 1`] = `
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
+  box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 
 .emotion-0:active {
@@ -181,6 +183,7 @@ exports[`variants filled (default) 1`] = `
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
+  box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 
 .emotion-0:active {
@@ -245,6 +248,7 @@ exports[`variants ghost 1`] = `
   color: var(--theme-ui-colors-brand-primary,#337ab7);
   -webkit-text-decoration: none;
   text-decoration: none;
+  box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 
 <button

--- a/src/components/bookDetails/__tests__/__snapshots__/BookDetails.test.tsx.snap
+++ b/src/components/bookDetails/__tests__/__snapshots__/BookDetails.test.tsx.snap
@@ -83,6 +83,7 @@ exports[`book details page handles error state 1`] = `
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
+  box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 
 .emotion-2:active {

--- a/src/components/bookDetails/__tests__/__snapshots__/BookDetails.test.tsx.snap
+++ b/src/components/bookDetails/__tests__/__snapshots__/BookDetails.test.tsx.snap
@@ -83,6 +83,9 @@ exports[`book details page handles error state 1`] = `
   color: white;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.emotion-2:focus {
   box-shadow: 0 0 0 0.2em rgba(0,109,255,0.4);
 }
 

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -28,7 +28,8 @@ const zIndices = {
 };
 
 const shadows = {
-  modal: "0px 2px 7px 3px rgba(0,0,0,0.3)"
+  modal: "0px 2px 7px 3px rgba(0,0,0,0.3)",
+  focus: "0 0 0 0.2em rgba(0, 109, 255, 0.4)"
 };
 
 const theme = {


### PR DESCRIPTION
- focus was barely visible in Firefox since it was using browser defaults instead of styling from circulation-patron-web
- updated to use the same focus style as the Reakit button example: https://reakit.io/docs/button/#main 


After (in Firefox)
- filled/img button <img width="1282" alt="Screen Shot 2020-08-25 at 12 24 38 PM" src="https://user-images.githubusercontent.com/6998954/91201043-f917eb80-e6cd-11ea-8583-43b2c4f4e31b.png">
- ghost button <img width="1281" alt="Screen Shot 2020-08-25 at 12 24 19 PM" src="https://user-images.githubusercontent.com/6998954/91201046-f9b08200-e6cd-11ea-86d4-92a738670771.png">

Before (in Firefox)
<img width="470" alt="Screen Shot 2020-08-17 at 10 18 35 AM" src="https://user-images.githubusercontent.com/6998954/91201309-47c58580-e6ce-11ea-9872-59cb66069eeb.png">



