### PR TITLE
a11y: resolve lang and heading aXe related issues

### DIFF
--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -22,7 +22,7 @@ import ReportProblem from "./ReportProblem";
 import useTypedSelector from "../../hooks/useTypedSelector";
 import { NavButton } from "../Button";
 import Head from "next/head";
-import { H3, Text, H1 } from "components/Text";
+import { H2, Text, H1 } from "components/Text";
 import MediumIndicator from "components/MediumIndicator";
 import SimplyELogo from "components/SimplyELogo";
 import IosBadge from "components/storeBadges/IosBadge";
@@ -109,7 +109,7 @@ const Summary: React.FC<{ book: BookData; className?: string }> = ({
   className
 }) => (
   <div sx={{ my: 2 }} className={className} aria-label="Book summary">
-    <H3 sx={{ mb: 2 }}>Summary</H3>
+    <H2 sx={{ mb: 2 }}>Summary</H2>
     <div
       dangerouslySetInnerHTML={{
         __html: book.summary ?? "Summary not provided."

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -109,7 +109,7 @@ const Summary: React.FC<{ book: BookData; className?: string }> = ({
   className
 }) => (
   <div sx={{ my: 2 }} className={className} aria-label="Book summary">
-    <H2 sx={{ mb: 2 }}>Summary</H2>
+    <H2 sx={{ mb: 2, variant: "text.headers.tertiary" }}>Summary</H2>
     <div
       dangerouslySetInnerHTML={{
         __html: book.summary ?? "Summary not provided."

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -22,7 +22,7 @@ import ReportProblem from "./ReportProblem";
 import useTypedSelector from "../../hooks/useTypedSelector";
 import { NavButton } from "../Button";
 import Head from "next/head";
-import { H2, Text, H1 } from "components/Text";
+import { H1, H2, H3, Text } from "components/Text";
 import MediumIndicator from "components/MediumIndicator";
 import SimplyELogo from "components/SimplyELogo";
 import IosBadge from "components/storeBadges/IosBadge";

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,11 +2,6 @@ import * as React from "react";
 import Document, { Html, Head, Main, NextScript } from "next/document";
 
 class MyDocument extends Document {
-  static async getInitialProps(ctx) {
-    const initialProps = await Document.getInitialProps(ctx);
-    return { ...initialProps };
-  }
-
   render() {
     return (
       <Html lang="en">

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;


### PR DESCRIPTION
> <html> element must have a lang attribute. 
This PR adds `_document.tsx` to set the HTML lang to `en` by default. 

On the book details the title is h1 but the summary is h3. This PR updates the summary to H2 with the same styles applied.
> moderate: Heading levels should only increase by one https://dequeuniversity.com/rules/axe/3.5/heading-order?application=axeAPI