### PR TITLE
Fix decryptor tsc errors

### DIFF
--- a/src/components/WebpubViewer.tsx
+++ b/src/components/WebpubViewer.tsx
@@ -18,9 +18,9 @@ const initializeReader = async (
       fetcher: DataFetcher,
       webpubManifestUrl: any
     ) => {
-      const Decryptor = await import(
-        "../../axisnow-access-control-web/src/decryptor"
-      );
+      const decryptorLocation =
+        "../../axisnow-access-control-web/src/decryptor";
+      const Decryptor = await import(decryptorLocation);
       if (Decryptor) {
         try {
           const fulfillmentData = await fetcher.fetch(webpubManifestUrl);

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -80,8 +80,9 @@ async function initBookSettings(
   const paginator = new ColumnsPaginatedBookView();
   const scroller = new ScrollingBookView();
 
+  const decryptorLocation = "../../axisnow-access-control-web/src/decryptor";
   const Decryptor = NEXT_PUBLIC_AXIS_NOW_DECRYPT
-    ? await import("../../axisnow-access-control-web/src/decryptor")
+    ? await import(decryptorLocation)
     : undefined;
   const decryptor = Decryptor
     ? await Decryptor.default.createDecryptor(decryptorParams)


### PR DESCRIPTION
Re-assigns decryptor location so that tsc doesn't throw an error when the decryptor submodule is not available. 