### PR TITLE
Fix eslint in axisnow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
     node: true
   },
   parser: "@typescript-eslint/parser",
-  ignorePatterns: ["/axisnow-access-control-web/**"],
   parserOptions: {
     project: "tsconfig.json",
     sourceType: "module",


### PR DESCRIPTION
This fixes the axisnow eslint setting so that submodule continues to be linted