### PR TITLE
Uses ts-ignore instead of dynamic imports

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -4,22 +4,33 @@ name: Publish beta
 # action will only run when a pull request to the beta branch is closed.
 on:
   pull_request:
-  #T TODO: revert once this works
-    types: [opened, synchronize, reopened]
-
+    branches: [beta]
+    types: [closed]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   publish_beta:
     name: Publish beta image to Docker Hub
     # only run if the PR is merged.
-    # TODO: REVERT if: github.event.pull_request.merged
+    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          token: ${{ secrets.AXIS_NOW_ACCESS_TOKEN }}
+
+      - id: nvmrc
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Use Node Version from nvmrc
+        uses: actions/setup-node@v1
+        with: { node-version: '${{ steps.nvmrc.outputs.NODE_VERSION }}' }
+
       - name: Get short SHA
         id: get_sha
         run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+
       - name: Publish to Docker Hub
         id: publish_docker_hub
         uses: docker/build-push-action@v2

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -4,18 +4,19 @@ name: Publish beta
 # action will only run when a pull request to the beta branch is closed.
 on:
   pull_request:
-    branches: [beta]
-    types: [closed]
+  #T TODO: revert once this works
+    types: [opened, synchronize, reopened]
+
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   publish_beta:
     name: Publish beta image to Docker Hub
     # only run if the PR is merged.
-    if: github.event.pull_request.merged
+    # TODO: REVERT if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - name: Get short SHA
         id: get_sha
         run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
@@ -25,6 +26,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: nypl/patron-web
           # tag the image with both beta and beta.short_sha
           tags: nypl/patron-web.beta, nypl/patron-web.beta.${{ steps.get_sha.outputs.short_sha }}
           add_git_labels: true

--- a/src/components/WebpubViewer.tsx
+++ b/src/components/WebpubViewer.tsx
@@ -18,8 +18,11 @@ const initializeReader = async (
       fetcher: DataFetcher,
       webpubManifestUrl: any
     ) => {
-      // const decryptorModule = "axisnow-access-control-web";
-      const Decryptor = await import(`../../axisnow-access-control-web/src/decryptor`);
+      const Decryptor = await import(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        "../../axisnow-access-control-web/src/decryptor"
+      );
       if (Decryptor) {
         try {
           const fulfillmentData = await fetcher.fetch(webpubManifestUrl);

--- a/src/components/WebpubViewer.tsx
+++ b/src/components/WebpubViewer.tsx
@@ -18,8 +18,8 @@ const initializeReader = async (
       fetcher: DataFetcher,
       webpubManifestUrl: any
     ) => {
-      const decryptorModule = "axisnow-access-control-web";
-      const Decryptor = await import(`../../${decryptorModule}/src/decryptor`);
+      // const decryptorModule = "axisnow-access-control-web";
+      const Decryptor = await import(`../../axisnow-access-control-web/src/decryptor`);
       if (Decryptor) {
         try {
           const fulfillmentData = await fetcher.fetch(webpubManifestUrl);

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -80,9 +80,9 @@ async function initBookSettings(
   const paginator = new ColumnsPaginatedBookView();
   const scroller = new ScrollingBookView();
 
-  const decryptorModule = "axisnow-access-control-web";
+  // const decryptorModule = "axisnow-access-control-web";
   const Decryptor = NEXT_PUBLIC_AXIS_NOW_DECRYPT
-    ? await import(`../../${decryptorModule}/src/decryptor`)
+    ? await import(`../../axisnow-access-control-web/src/decryptor`)
     : undefined;
   const decryptor = Decryptor
     ? await Decryptor.default.createDecryptor(decryptorParams)

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -80,9 +80,10 @@ async function initBookSettings(
   const paginator = new ColumnsPaginatedBookView();
   const scroller = new ScrollingBookView();
 
-  // const decryptorModule = "axisnow-access-control-web";
   const Decryptor = NEXT_PUBLIC_AXIS_NOW_DECRYPT
-    ? await import(`../../axisnow-access-control-web/src/decryptor`)
+    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      await import("../../axisnow-access-control-web/src/decryptor")
     : undefined;
   const decryptor = Decryptor
     ? await Decryptor.default.createDecryptor(decryptorParams)


### PR DESCRIPTION
the interaction of TS/Node/Webpack/Babel means that dynamic imports are tricky, and debugging in different environments is causing different errors.  I

The root cause of this is that importing "axis-now-access-control/decryptor" throws a tsc error when the repo doesn't have access to the submodule.  I've gone and suppressed that warning.  

Based on the convos in slack earlier today, we might eventually take this out completely, and I think this is yet another point in favor of doing that.  