### PR TITLE
update webpub-viewer to 0.2.2 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4463,9 +4463,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
-      "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -10358,9 +10358,9 @@
       }
     },
     "library-simplified-webpub-viewer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/library-simplified-webpub-viewer/-/library-simplified-webpub-viewer-0.2.1.tgz",
-      "integrity": "sha512-Mh7Uu7UzFBOfkGyu3wYse4l68UYpeIreEn0fyXPtBjmwteQ88UgprlFlUt0EnvN5tMYC0bw8dMNKHUuCmSplag==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/library-simplified-webpub-viewer/-/library-simplified-webpub-viewer-0.2.2.tgz",
+      "integrity": "sha512-gWk3ij0ii5rl23Qf8QSU/icEcvgc5ddQBAC8AcLDQEO7Uw8SSXdnpliqLSggGgcXt60JSSuDVrf0AoUZiC6Gdg==",
       "requires": {
         "cpx": "^1.5.0",
         "ejs": "^2.4.1",
@@ -11388,9 +11388,9 @@
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -14292,11 +14292,11 @@
       "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA=="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "font-awesome": "^4.7.0",
     "history": "^4.10.1",
     "jsdom": "^16.2.2",
-    "library-simplified-webpub-viewer": "0.2.1",
+    "library-simplified-webpub-viewer": "0.2.2",
     "lodash": "^4.17.20",
     "moment": "^2.24.0",
     "next": "^9.5.3",


### PR DESCRIPTION
- Upgrade webpub-viewer to 0.2.2 to pull in the latest updates to parsing e-books (https://github.com/NYPL-Simplified/webpub-viewer/pull/172)