### PR TITLE
Axisnow issue

### DIFF
--- a/.env
+++ b/.env
@@ -6,4 +6,5 @@ CONFIG_FILE=/community-config.yml
 # unexpectedly turn it on.
 # REACT_AXE=true
 
-NEXT_PUBLIC_AXISNOW_DECRYPT=false
+# turn this on to enable axisnow decryption
+# NEXT_PUBLIC_AXISNOW_DECRYPT=true

--- a/.env
+++ b/.env
@@ -5,3 +5,5 @@ CONFIG_FILE=/community-config.yml
 # process.env values are strings, so setting this to "false" will
 # unexpectedly turn it on.
 # REACT_AXE=true
+
+NEXT_PUBLIC_AXISNOW_DECRYPT=false

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following environment variables can be set to further configure the applicat
 
 - Set `AXE_TEST=true` to run the application with `react-axe` enabled (only works when `NODE_ENV` is "development").
 - Set `ANALYZE=true` to generate bundle analysis files inside `.next/analyze` which will show bundle sizes for server and client, as well as composition.
+- Set `NEXT_PUBLIC_AXISNOW_DECRYPT=true` to indicate that the build environment has access to the axisnow decryptor submodule. Default is false.
 
 ## Manager, Registry, and Application Configurations
 

--- a/community-config.yml
+++ b/community-config.yml
@@ -39,11 +39,6 @@ media_support:
 # default is "simplye"
 companion_app: simplye
 
-# tells the app that it should attempt to decrypt AxisNow documents
-# the default is false. Only set this to true if the build environment
-# has access to the axisnow submodule
-# axisnow_decrypt: true
-
 # defines the bugsnag api key to integrate error tracking
 # bugsnag_api_key: xxx
 

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const {
   BugsnagBuildReporterPlugin,
   BugsnagSourceMapUploaderPlugin
 } = require("webpack-bugsnag-plugins");
+const path = require("path");
 
 const APP_VERSION = require("./package.json").version;
 
@@ -30,6 +31,20 @@ const config = {
       config.node = {
         fs: "empty"
       };
+    }
+
+    // stub out the axisnow decryptor if we don't have access to it
+    if (process.env.NEXT_PUBLIC_AXISNOW_DECRYPT) {
+      console.log("Running with AxisNow Decryption");
+      config.resolve.alias.AxisNowDecryptor = path.resolve(
+        __dirname,
+        "axisnow-access-control-web/src/decryptor"
+      );
+    } else {
+      config.resolve.alias.AxisNowDecryptor = path.resolve(
+        __dirname,
+        "src/utils/stub-decryptor"
+      );
     }
 
     // add bugsnag if we are not in dev

--- a/next.config.js
+++ b/next.config.js
@@ -11,10 +11,8 @@ const APP_VERSION = require("./package.json").version;
 
 const config = {
   env: {
-    SIMPLIFIED_CATALOG_BASE: process.env.SIMPLIFIED_CATALOG_BASE,
     CONFIG_FILE: process.env.CONFIG_FILE,
     REACT_AXE: process.env.REACT_AXE,
-    CACHE_EXPIRATION_SECONDS: process.env.CACHE_EXPIRATION_SECONDS,
     APP_VERSION
   },
   webpack: (config, { _buildId, dev, isServer, _defaultLoaders, webpack }) => {

--- a/src/components/WebpubViewer.tsx
+++ b/src/components/WebpubViewer.tsx
@@ -7,7 +7,6 @@ import fetchWithHeaders from "dataflow/fetch";
 import extractParam from "dataflow/utils";
 import { PageNotFoundError, ServerError } from "errors";
 import useAuthModalContext from "auth/AuthModalContext";
-import { APP_CONFIG } from "config";
 
 const initializeReader = async (
   entryUrl: string,
@@ -15,7 +14,7 @@ const initializeReader = async (
   token: string
 ) => {
   const loadDecryptorParams = async (webpubManifestUrl: any) => {
-    if (!APP_CONFIG.axisNowDecrypt) return;
+    if (!process.env.NEXT_PUBLIC_AXISNOW_DECRYPT) return;
     const response = await fetchWithHeaders(webpubManifestUrl, token);
     const data = await response.json();
     // there should never be a status code in the json

--- a/src/components/WebpubViewer.tsx
+++ b/src/components/WebpubViewer.tsx
@@ -7,6 +7,7 @@ import fetchWithHeaders from "dataflow/fetch";
 import extractParam from "dataflow/utils";
 import { PageNotFoundError, ServerError } from "errors";
 import useAuthModalContext from "auth/AuthModalContext";
+import { AXISNOW_DECRYPT } from "utils/env";
 
 const initializeReader = async (
   entryUrl: string,
@@ -14,7 +15,7 @@ const initializeReader = async (
   token: string
 ) => {
   const loadDecryptorParams = async (webpubManifestUrl: any) => {
-    if (!process.env.NEXT_PUBLIC_AXISNOW_DECRYPT) return;
+    if (!AXISNOW_DECRYPT) return;
     const response = await fetchWithHeaders(webpubManifestUrl, token);
     const data = await response.json();
     // there should never be a status code in the json

--- a/src/components/__tests__/WebpubViewer.test.tsx
+++ b/src/components/__tests__/WebpubViewer.test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { mockShowAuthModal, render } from "test-utils";
 import WebpubViewer from "components/WebpubViewer";
 import { PageNotFoundError } from "errors";
+import * as env from "utils/env";
 
 jest.mock("utils/reader", () => ({
   __esModule: true,
@@ -42,7 +43,7 @@ test("renders viewer div", () => {
 });
 
 test("fetches params with token if run with NEXT_PUBLIC_AXIS_NOW_DECRYPT", async () => {
-  process.env.NEXT_PUBLIC_AXISNOW_DECRYPT = "true";
+  (env as any).AXISNOW_DECRYPT = "true";
   render(<WebpubViewer />, {
     router: { query: { bookUrl: "http://some-book.com" } }
   });

--- a/src/components/__tests__/WebpubViewer.test.tsx
+++ b/src/components/__tests__/WebpubViewer.test.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { mockShowAuthModal, render } from "test-utils";
 import WebpubViewer from "components/WebpubViewer";
 import { PageNotFoundError } from "errors";
-import mockConfig from "test-utils/mockConfig";
 
 jest.mock("utils/reader", () => ({
   __esModule: true,
@@ -43,7 +42,7 @@ test("renders viewer div", () => {
 });
 
 test("fetches params with token if run with NEXT_PUBLIC_AXIS_NOW_DECRYPT", async () => {
-  mockConfig({ axisNowDecrypt: true });
+  process.env.NEXT_PUBLIC_AXISNOW_DECRYPT = "true";
   render(<WebpubViewer />, {
     router: { query: { bookUrl: "http://some-book.com" } }
   });

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -15,6 +15,7 @@ import {
 import { ProblemDocument } from "types/opds1";
 import fetchMock from "jest-fetch-mock";
 import { mockPush } from "test-utils/mockNextRouter";
+import * as env from "utils/env";
 
 jest.mock("downloadjs");
 window.open = jest.fn();
@@ -273,7 +274,8 @@ describe("FulfillableBook", () => {
 
   test("constructs link to viewer for OpenAxis Books", () => {
     mockConfig({ companionApp: "openebooks" });
-    process.env.NEXT_PUBLIC_AXISNOW_DECRYPT = "true";
+    (env as any).AXISNOW_DECRYPT = "true";
+
     const utils = render(<FulfillmentCard book={viewableAxisNowBook} />);
     const readerButton = utils.getByRole("button", {
       name: /Read/i
@@ -329,7 +331,7 @@ describe("FulfillableBook", () => {
   });
 
   test("internal read online button tracks open_book event", async () => {
-    process.env.NEXT_PUBLIC_AXISNOW_DECRYPT = "true";
+    (env as any).AXISNOW_DECRYPT = "true";
     const readOnlineBook = mergeBook<FulfillableBook>({
       status: "fulfillable",
       revokeUrl: "/revoke",

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -272,7 +272,8 @@ describe("FulfillableBook", () => {
   });
 
   test("constructs link to viewer for OpenAxis Books", () => {
-    mockConfig({ companionApp: "openebooks", axisNowDecrypt: true });
+    mockConfig({ companionApp: "openebooks" });
+    process.env.NEXT_PUBLIC_AXISNOW_DECRYPT = "true";
     const utils = render(<FulfillmentCard book={viewableAxisNowBook} />);
     const readerButton = utils.getByRole("button", {
       name: /Read/i
@@ -328,7 +329,7 @@ describe("FulfillableBook", () => {
   });
 
   test("internal read online button tracks open_book event", async () => {
-    mockConfig({ axisNowDecrypt: true });
+    process.env.NEXT_PUBLIC_AXISNOW_DECRYPT = "true";
     const readOnlineBook = mergeBook<FulfillableBook>({
       status: "fulfillable",
       revokeUrl: "/revoke",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,7 +5,6 @@ function parseConfig(unparsed: any): AppConfig {
   // specifically set defaults for a couple values.
   const companionApp =
     unparsed.companion_app === "openebooks" ? "openebooks" : "simplye";
-  const axisNowDecrypt = unparsed.axisnow_decrypt === true;
 
   // otherwise assume the file is properly structured.
   return {
@@ -13,7 +12,6 @@ function parseConfig(unparsed: any): AppConfig {
     mediaSupport: unparsed.media_support ?? {},
     bugsnagApiKey: unparsed.bugsnagApiKey ?? null,
     gtmId: unparsed.gtmId ?? null,
-    axisNowDecrypt,
     companionApp
   };
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,7 +20,6 @@ export type AppConfig = {
   mediaSupport: MediaSupportConfig;
   libraries: LibraryRegistryBase | LibrariesConfig;
   companionApp: "simplye" | "openebooks";
-  axisNowDecrypt: boolean;
   bugsnagApiKey: string | null;
   gtmId: string | null;
 };

--- a/src/test-utils/mockConfig.ts
+++ b/src/test-utils/mockConfig.ts
@@ -12,7 +12,6 @@ const defaultMock: AppConfig = {
   bugsnagApiKey: null,
   gtmId: null,
   companionApp: "simplye",
-  axisNowDecrypt: true,
   libraries: {
     lib1: "http://lib1.com"
   },

--- a/src/types/declarations/AxisNowDecryptor.d.ts
+++ b/src/types/declarations/AxisNowDecryptor.d.ts
@@ -1,0 +1,18 @@
+declare module "AxisNowDecryptor" {
+  import IDecryptor from "library-simplified-webpub-viewer/dist/Decryptor";
+
+  class Decryptor implements IDecryptor {
+    readonly keyPair: CryptoKeyPair;
+    readonly contentKey: CryptoKey;
+    readonly containerUrl: string;
+    static createDecryptor(params: any): Promise<Decryptor>;
+    private constructor();
+    getEntryUrl(): string;
+    private decrypt;
+    decryptUrl(resourceUrl: string): Promise<Uint8Array>;
+  }
+
+  declare const defaultExport: false | typeof Decryptor;
+
+  export default defaultExport;
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -9,3 +9,4 @@ export const REACT_AXE = process.env.REACT_AXE;
 export const IS_DEVELOPMENT = process.env.NODE_ENV === "development";
 export const IS_SERVER = typeof window === "undefined";
 export const APP_VERSION = process.env.APP_VERSION;
+export const AXISNOW_DECRYPT = process.env.NEXT_PUBLIC_AXISNOW_DECRYPT;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -9,3 +9,7 @@ export const REACT_AXE = process.env.REACT_AXE;
 export const IS_DEVELOPMENT = process.env.NODE_ENV === "development";
 export const IS_SERVER = typeof window === "undefined";
 export const APP_VERSION = process.env.APP_VERSION;
+
+export const AXISNOW_DECRYPTOR_PATH = process.env.NEXT_PUBLIC_AXISNOW_DECRYPTOR
+  ? "../../axisnow-access-control-web/src/decryptor"
+  : "./stub-decruptor.ts";

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -9,7 +9,3 @@ export const REACT_AXE = process.env.REACT_AXE;
 export const IS_DEVELOPMENT = process.env.NODE_ENV === "development";
 export const IS_SERVER = typeof window === "undefined";
 export const APP_VERSION = process.env.APP_VERSION;
-
-export const AXISNOW_DECRYPTOR_PATH = process.env.NEXT_PUBLIC_AXISNOW_DECRYPTOR
-  ? "../../axisnow-access-control-web/src/decryptor"
-  : "./stub-decruptor.ts";

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -93,7 +93,7 @@ export function getFulfillmentDetails(
 
     case OPDS1.AxisNowWebpubMediaType:
       // you can only read these if you can decrypt them.
-      if (!APP_CONFIG.axisNowDecrypt) {
+      if (!process.env.NEXT_PUBLIC_AXISNOW_DECRYPT) {
         return { type: "unsupported" };
       }
       return {

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -7,6 +7,7 @@ import {
   MediaSupportLevel,
   OPDS1
 } from "interfaces";
+import { AXISNOW_DECRYPT } from "utils/env";
 import { typeMap } from "utils/file";
 
 /**
@@ -93,7 +94,7 @@ export function getFulfillmentDetails(
 
     case OPDS1.AxisNowWebpubMediaType:
       // you can only read these if you can decrypt them.
-      if (!process.env.NEXT_PUBLIC_AXISNOW_DECRYPT) {
+      if (!AXISNOW_DECRYPT) {
         return { type: "unsupported" };
       }
       return {

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -15,6 +15,7 @@ import {
 } from "library-simplified-webpub-viewer";
 import fetchWithHeaders from "dataflow/fetch";
 import ApplicationError from "errors";
+import { AXISNOW_DECRYPTOR_PATH } from "utils/env";
 
 export default async function reader(
   bookUrl: string,
@@ -87,7 +88,7 @@ async function initBookSettings(
     const Decryptor = process.env.NEXT_PUBLIC_AXISNOW_DECRYPT
       ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        await import("../../axisnow-access-control-web/src/decryptor")
+        await import(AXISNOW_DECRYPTOR_PATH)
       : undefined;
     decryptor = Decryptor
       ? await Decryptor.default.createDecryptor(decryptorParams)

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -15,7 +15,7 @@ import {
 } from "library-simplified-webpub-viewer";
 import fetchWithHeaders from "dataflow/fetch";
 import ApplicationError from "errors";
-import { AXISNOW_DECRYPTOR_PATH } from "utils/env";
+import Decryptor from "AxisNowDecryptor";
 
 export default async function reader(
   bookUrl: string,
@@ -85,13 +85,8 @@ async function initBookSettings(
   let decryptor: any = undefined;
 
   try {
-    const Decryptor = process.env.NEXT_PUBLIC_AXISNOW_DECRYPT
-      ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        await import(AXISNOW_DECRYPTOR_PATH)
-      : undefined;
     decryptor = Decryptor
-      ? await Decryptor.default.createDecryptor(decryptorParams)
+      ? await Decryptor.createDecryptor(decryptorParams)
       : undefined;
   } catch (e) {
     throw new ApplicationError(

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -15,7 +15,6 @@ import {
 } from "library-simplified-webpub-viewer";
 import fetchWithHeaders from "dataflow/fetch";
 import ApplicationError from "errors";
-import { APP_CONFIG } from "config";
 
 export default async function reader(
   bookUrl: string,
@@ -85,7 +84,7 @@ async function initBookSettings(
   let decryptor: any = undefined;
 
   try {
-    const Decryptor = APP_CONFIG.axisNowDecrypt
+    const Decryptor = process.env.NEXT_PUBLIC_AXISNOW_DECRYPT
       ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         await import("../../axisnow-access-control-web/src/decryptor")

--- a/src/utils/stub-decryptor.ts
+++ b/src/utils/stub-decryptor.ts
@@ -2,8 +2,4 @@
  * This is a file that can be required by apps that don't have access to the axisnow decryptor
  */
 
-throw new Error(
-  "This application mistakenly required the AxisNow Decryptor, when it does not have access"
-);
-
-export default {};
+export default false;

--- a/src/utils/stub-decryptor.ts
+++ b/src/utils/stub-decryptor.ts
@@ -1,0 +1,9 @@
+/**
+ * This is a file that can be required by apps that don't have access to the axisnow decryptor
+ */
+
+throw new Error(
+  "This application mistakenly required the AxisNow Decryptor, when it does not have access"
+);
+
+export default {};


### PR DESCRIPTION
We need to move the variable that indicates access to the axisnow decryptor back to an environment variable, and also stub it for when it isn't accessible to avoid webpack errors on build