### PR TITLE
Push state from 404

### DIFF
--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -72,7 +72,6 @@ const LibraryList: React.FC<{ libraries: string[] }> = ({ libraries }) => {
         {libraries.map(lib => (
           <li key={lib}>
             <Link
-              replace
               sx={{
                 ...buttonBase,
                 display: "block",


### PR DESCRIPTION
This reverses something I did which I thought would be nice, but isn't nice at all. From the 404 page, when you click a link to a library home page, we now push that state into history instead of replacing it, so you can go back to choose another.