### PR TITLE
List filters delay

### DIFF
--- a/src/components/FulfillmentButton.tsx
+++ b/src/components/FulfillmentButton.tsx
@@ -123,7 +123,7 @@ const ReadOnlineInternal: React.FC<{
   const internalLink = buildMultiLibraryLink(details.url);
   function open() {
     track.openBook(trackOpenBookUrl);
-    router.push(internalLink);
+    router.push(internalLink, undefined, { shallow: true });
   }
   return (
     <Button {...getButtonStyles(isPrimaryAction)} onClick={open}>

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -62,7 +62,10 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       prefetch,
       replace,
       scroll,
-      shallow,
+      // default to shallow routing because we don't fetch any
+      // page-specific data in getStaticProps. See more:
+      // https://nextjs.org/docs/routing/shallow-routing
+      shallow = true,
       ...rest
     } = buildLinkFromProps(props, linkUtils);
     return (

--- a/src/components/ListFilters.tsx
+++ b/src/components/ListFilters.tsx
@@ -42,7 +42,9 @@ const FacetSelector: React.FC<{
 
     if (!facet?.href) return;
     const url = linkUtils.buildCollectionLink(facet.href);
-    Router.push(url);
+    // shallow route because we don't need to rerun getStaticProps for the new page,
+    // just fetch the new collection client-side
+    Router.push(url, undefined, { shallow: true });
   };
   return (
     <div sx={{ m: 1 }}>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -37,7 +37,7 @@ const Search: React.FC<SearchProps> = ({ className, ...props }) => {
     );
     if (!url) return;
     const link = linkUtils.buildCollectionLink(url);
-    Router.push(link);
+    Router.push(link, undefined, { shallow: true });
   };
 
   return (

--- a/src/components/__tests__/ListFilters.test.tsx
+++ b/src/components/__tests__/ListFilters.test.tsx
@@ -116,7 +116,11 @@ test("does redirect when selected", () => {
 
   expect(mockedRouter.push).toHaveBeenCalledTimes(1);
   expect(mockedRouter.push).toHaveBeenCalledWith(
-    "/testlib/collection/http%3A%2F%2Ftitle"
+    "/testlib/collection/http%3A%2F%2Ftitle",
+    undefined,
+    {
+      shallow: true
+    }
   );
 });
 
@@ -186,7 +190,11 @@ describe("Format filters", () => {
     userEvent.selectOptions(select, "All");
     expect(mockPush).toHaveBeenCalledTimes(1);
     expect(mockPush).toHaveBeenCalledWith(
-      "/testlib/collection/http%3A%2F%2Fall"
+      "/testlib/collection/http%3A%2F%2Fall",
+      undefined,
+      {
+        shallow: true
+      }
     );
   });
 });

--- a/src/components/__tests__/Search.test.tsx
+++ b/src/components/__tests__/Search.test.tsx
@@ -34,7 +34,11 @@ test("searching calls history.push with url", async () => {
 
   // assert
   expect(mockPush).toHaveBeenCalledTimes(1);
-  expect(mockPush).toHaveBeenCalledWith(
-    "/testlib/collection/http%3A%2F%2Fsearch-url%2Fsearch%2Fmy%2520search"
+  expect(
+    mockPush
+  ).toHaveBeenCalledWith(
+    "/testlib/collection/http%3A%2F%2Fsearch-url%2Fsearch%2Fmy%2520search",
+    undefined,
+    { shallow: true }
   );
 });


### PR DESCRIPTION
This PR fixes the performance problem we saw when switching between list filters. I'll try to explain the underlying problem...

- The app uses `getStaticProps` for every page to fetch the library data we need. This means that the first time a route is requested, `getStaticProps` is run server-side, and then the page is rendered using that data. For the time being, this only loads the information we need for the library, so basically just the layout (the logo, library name, colors, etc). The actual collection or book data is fetched client-side (for now).
- Once we run `getStaticProps` on the server, the HTML that generates is sent to the client, and then cached. So subsequent requests to that page will be immediately responded to with the HTML already generated and ready on the server. The app will revalidate this cached data according to a schedule we set up in `withAppProps`. 
- So, by default, every page requires the server data from `getStaticProps`, and navigation will be delayed until that data is returned.
- Next.js (for the time being) doesn't know that every page within one library route (`/library/...`) uses the same data, it's not unique to every page. So that means that when you navigate from `/library/collection/collectionUrl` to `/library/collection/collectionUrl2`, the app thinks it needs new server-side data and will wait for `getStaticProps` to return. If that page had already been rendered, it would be cached and therefore not very slow, but it still wouldn't be as fast as if we just reused the old library data and changed the url immediately. 
- Next.js provides a [shallow routing](https://nextjs.org/docs/routing/shallow-routing) option to tell the app to do just that: route to the new page, but don't refetch the server-side data... assume all the data can be fetched client side. 
- It turns out, since all page-specific data is currently fetched client-side, we can use shallow routing everywhere. So I just updated to do that.
- The one place we can't use shallow routing is when we are navigating from the 404 page, because different libraries do actually have different data returned from the server, so we would end up in an error state. 
- I turned on shallow routing everywhere, so we should see increased performance anytime we are navigating between two pages that share the same path (`/collection/:collectionUrl` -> `/collection/:collectionUrl2` or `/book/:bookUrl` -> `/book/:bookUrl2`)


Also, just in case you're wondering, I do plan eventually to turn on full server-side data fetching, so the book details and the collection are fetched server side as well in `getStaticProps`. We just haven't gotten around to it yet. 