### PR TITLE
Stable loans sort

### DIFF
--- a/src/components/MyBooks.tsx
+++ b/src/components/MyBooks.tsx
@@ -19,11 +19,22 @@ function sortBooksByLoanExpirationDate(books: AnyBook[]) {
   return books.sort((a, b) => {
     const aDate = availableUntil(a);
     const bDate = availableUntil(b);
+    // if there is no availability info for either, compare their titles
+    if (typeof aDate === "string" && typeof bDate === "string") {
+      return compareTitles(a, b);
+    }
+    // if only one has a defined availability, it goes on top
     if (typeof aDate === "string") return 1;
     if (typeof bDate === "string") return -1;
+    // if both have defined availabilities, sort by date
     if (aDate <= bDate) return -1;
     return 1;
   });
+}
+
+function compareTitles(a: AnyBook, b: AnyBook): 0 | -1 | 1 {
+  if (a.title > b.title) return 1;
+  return -1;
 }
 
 export const MyBooks: React.FC = () => {

--- a/src/components/MyBooks.tsx
+++ b/src/components/MyBooks.tsx
@@ -27,8 +27,9 @@ function sortBooksByLoanExpirationDate(books: AnyBook[]) {
     if (typeof aDate === "string") return 1;
     if (typeof bDate === "string") return -1;
     // if both have defined availabilities, sort by date
-    if (aDate <= bDate) return -1;
-    return 1;
+    if (aDate < bDate) return -1;
+    if (aDate > bDate) return 1;
+    return compareTitles(a, b);
   });
 }
 

--- a/src/components/MyBooks.tsx
+++ b/src/components/MyBooks.tsx
@@ -29,6 +29,7 @@ function sortBooksByLoanExpirationDate(books: AnyBook[]) {
     // if both have defined availabilities, sort by date
     if (aDate < bDate) return -1;
     if (aDate > bDate) return 1;
+    // if both dates are the same, sort by title
     return compareTitles(a, b);
   });
 }

--- a/src/components/__tests__/MyBooks.test.tsx
+++ b/src/components/__tests__/MyBooks.test.tsx
@@ -114,4 +114,6 @@ test("sorts books", () => {
   const bookNames = utils.queryAllByText(/Book Title/);
   expect(bookNames[0]).toHaveTextContent("Book Title 11");
   expect(bookNames[1]).toHaveTextContent("Book Title 10");
+  expect(bookNames[2]).toHaveTextContent("Book Title 0");
+  expect(bookNames[3]).toHaveTextContent("Book Title 1");
 });

--- a/src/components/__tests__/MyBooks.test.tsx
+++ b/src/components/__tests__/MyBooks.test.tsx
@@ -75,6 +75,17 @@ const books: FulfillableBook[] = [
       until: "Jan 1 2020",
       status: "available"
     }
+  }),
+  fixtures.mergeBook<FulfillableBook>({
+    status: "fulfillable",
+    fulfillmentLinks: [fixtures.fulfillmentLink],
+    revokeUrl: "/revoke-12",
+    id: "book 12",
+    title: "Book Title 12",
+    availability: {
+      until: "Jan 1 2020",
+      status: "available"
+    }
   })
 ];
 
@@ -113,7 +124,8 @@ test("sorts books", () => {
   });
   const bookNames = utils.queryAllByText(/Book Title/);
   expect(bookNames[0]).toHaveTextContent("Book Title 11");
-  expect(bookNames[1]).toHaveTextContent("Book Title 10");
-  expect(bookNames[2]).toHaveTextContent("Book Title 0");
-  expect(bookNames[3]).toHaveTextContent("Book Title 1");
+  expect(bookNames[1]).toHaveTextContent("Book Title 12");
+  expect(bookNames[2]).toHaveTextContent("Book Title 10");
+  expect(bookNames[3]).toHaveTextContent("Book Title 0");
+  expect(bookNames[4]).toHaveTextContent("Book Title 1");
 });


### PR DESCRIPTION
This simple fix corrects the way that the loans page would resort after a second when you click the page. If two books don't have availability defined, we sort by title, which makes the sort "stable", meaning that it will return the same output every time if it is given the same input.