### PR TITLE
Bugfix/simply 3214 back forward lane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19969,6 +19969,11 @@
         "prop-types": "^15.0.0"
       }
     },
+    "react-intersection-observer": {
+      "version": "8.30.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.30.3.tgz",
+      "integrity": "sha512-hKYTJUrU99hAf7h1lNY3pjYXt+09BaPNC6fcLw1B8OLJJUDXTWrwzu4hRuztougeRgPYpxmNaTn1FS4F3EQnhA=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-dom": "16.13.1",
     "react-hook-form": "^4.9.2",
     "react-hot-loader": "^4.12.20",
+    "react-intersection-observer": "^8.30.3",
     "react-redux": "^7.1.0",
     "reakit": "^1.2.4",
     "request": "^2.88.2",

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -19,7 +19,9 @@ type BookRefs = {
 type CurrentBook = {
   index: number;
   /**
-   * The following dictates whether we snap to a book
+   * The following dictates whether we snap to a book. 
+   * "Snapping" to a book means we scroll the currentBook's
+   * left edge so that it is up against leftmost edge of the lane
    */
   snap: boolean;
 };

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -95,7 +95,7 @@ const Lane: React.FC<{
 
   // will be used to set a timeout when the browser is auto scrolling
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-  const browserScrollTime = 3000; // guess how long the browser takes to scroll
+  const browserScrollTime = 1000; // guess how long the browser takes to scroll
 
   /**
    * This effect is used to snap us to a particular book when the

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -73,18 +73,9 @@ const Lane: React.FC<{
   // we need a ref to the UL element so we can scroll it
   const scrollContainer = React.useRef<HTMLUListElement | null>(null);
 
-  // vars for when we are at beginning or end of lane
-  
-  const isAtIndexEnd = currentBook.index === filteredBooks.length - 1;
-  const isAtScrollEnd = !!(
-    scrollContainer.current &&
-    scrollContainer.current.scrollLeft ===
-      scrollContainer.current.scrollWidth - scrollContainer.current.offsetWidth
-  );
-  //const isAtEnd = !!(isAtIndexEnd || isAtScrollEnd);
-  //const isAtEnd = !!(currentBook.index + 1 > filteredBooks.length);
-  //const isAtStart = currentBook.index === 0;
-  const isAtStart = !!(currentBook.index - 1 < 0);
+  // vars for when we are at beginning of a lane
+
+  const isAtStart = currentBook.index === 0;
 
   /** Handlers for button clicks */
   const handleRightClick = () => {
@@ -166,10 +157,6 @@ const Lane: React.FC<{
 
   return (
     <li sx={{ m: 0, p: 0, mb: 4, listStyle: "none" }} aria-label={title}>
-      <p>{`start ${isAtStart}`}</p>
-      <p>{`end ${isAtEnd}`}</p>
-      <p>{`currentBook.index ${currentBook.index - 1}`}</p>
-      <p>{filteredBooks.length}</p>
       <Stack
         sx={{
           justifyContent: ["space-between", "initial"],
@@ -261,7 +248,6 @@ const SeeMoreBlock: React.FC<{ url: string; title: string, setIsAtEnd: (arg: boo
         }}
       >
         <Stack direction="column">
-          <Text>{inView.toString()}</Text>
           <Text>See All</Text>
           <Text variant="text.headers.tertiary">{title}</Text>
         </Stack>


### PR DESCRIPTION
Hi there!  I tried a bit of a different approach to determine when we're at the end of a lane.  Rather than using scroll-related information, which was inconsistent due to the scroll setTimeout, I tried a DOM observable.  Risa confirmed in an earlier chat that each lane will always have a "See More" card in it, so I set up an observable such that when 100% of the "See More" card is visible in the viewport, it will register as having scrolled to the end of the lane.

If you like this approach, we could apply it to the start of the row as well--currently, you have to have scrolled past the first book into order for the back button to enable, which might not be what you want.

I hope it was OK that I added a package?  I wasn't sure if that was cool; let me know.