### PR TITLE
Re-enable strict type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add: Button to go back to auth selection from basic auth if multiple methods are present.
 - Fix: Refactor See More card to use the same sizing and aspect ratio of the book cover images.
 - Fix: Fix delay between when you reach the end of a lane and when the forward/back arrows turn gray (disabled).
+- Refactor: Re-enabled Typescript's strict type checking to provide better runtime type safety guarantees, and keep type safety from deteriorating hrough development.
 
 ### 4.1.0
 - Add: Landing page for Open Ebooks

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -51,14 +51,14 @@ export const InfiniteBookList: React.FC<{ firstPageUrl: string }> = ({
   firstPageUrl
 }) => {
   const { token } = useUser();
-  function getKey(pageIndex: number, previousData: CollectionData) {
+  const getKey = (pageIndex: number, previousData: CollectionData | null) => {
     // first page, no previous data
     if (pageIndex === 0) return [firstPageUrl, token];
     // reached the end
-    if (!previousData.nextPageUrl) return null;
+    if (!previousData?.nextPageUrl) return null;
     // otherwise return the next page url
     return [previousData.nextPageUrl, token];
-  }
+  };
   const { data, size, error, setSize } = useSWRInfinite(
     getKey,
     fetchCollection
@@ -72,7 +72,7 @@ export const InfiniteBookList: React.FC<{ firstPageUrl: string }> = ({
 
   // extract the books from the array of collections in data
   const books =
-    data?.reduce(
+    data?.reduce<AnyBook[]>(
       (total, current) => [...total, ...(current.books ?? [])],
       []
     ) ?? [];

--- a/src/components/WebpubViewer.tsx
+++ b/src/components/WebpubViewer.tsx
@@ -13,7 +13,7 @@ const initializeReader = async (
   catalogName: string,
   token: string
 ) => {
-  const loadDecryptorParams = async (webpubManifestUrl: any) => {
+  const loadDecryptorParams = async (webpubManifestUrl: string) => {
     const response = await fetchWithHeaders(webpubManifestUrl, token);
     const data = await response.json();
     // there should never be a status code in the json

--- a/src/components/__tests__/Search.test.tsx
+++ b/src/components/__tests__/Search.test.tsx
@@ -21,7 +21,7 @@ const mockedSWR = useSWR as jest.MockedFunction<typeof useSWR>;
 const mockSwr: MockSwr<SearchData> = (
   value = makeSwrResponse({ data: fixtureData })
 ) => {
-  mockedSWR.mockImplementation(key => {
+  mockedSWR.mockImplementation((key: any) => {
     if (key?.[0] === "/collection")
       return makeSwrResponse({ data: fixtures.emptyCollection });
     return makeSwrResponse(value);

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -78,7 +78,7 @@ const FulfillmentContent: React.FC<{
  */
 const AccessCard: React.FC<{
   book: FulfillableBook;
-  links: FulfillmentLink[];
+  links: readonly FulfillmentLink[];
 }> = ({ book, links }) => {
   const fulfillments = getFulfillmentsFromBook(book);
 

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -140,7 +140,7 @@ describe("book details page", () => {
   test("shows recommendation lanes", () => {
     // we make a special mock so we can differentiate the book request
     // and the related collection request
-    mockedSWR.mockImplementation((key => {
+    mockedSWR.mockImplementation(((key: any) => {
       if (key === "/book-url") {
         return makeSwrResponse({
           data: {

--- a/src/components/bookDetails/__tests__/Recommendations.test.tsx
+++ b/src/components/bookDetails/__tests__/Recommendations.test.tsx
@@ -8,10 +8,10 @@ import { fetchCollection } from "dataflow/opds1/fetch";
 jest.mock("swr");
 
 const mockedSWR = useSWR as jest.MockedFunction<typeof useSWR>;
-
+type CollectionResponse = responseInterface<CollectionData, any>;
 function makeSwrResponse(
-  value: Partial<responseInterface<CollectionData, any>>
-) {
+  value: Partial<CollectionResponse>
+): CollectionResponse {
   return {
     data: undefined,
     error: undefined,
@@ -22,12 +22,12 @@ function makeSwrResponse(
   };
 }
 function mockSwr(
-  value: Partial<responseInterface<CollectionData, any>> = {
+  value: Partial<CollectionResponse> = {
     isValidating: false,
     data: fixtures.recommendations
   }
 ) {
-  mockedSWR.mockReturnValue(makeSwrResponse(value));
+  mockedSWR.mockReturnValue(makeSwrResponse(value) as any);
 }
 
 test("shows recommendations loading state", async () => {

--- a/src/components/stories/BookListItem/FulfillableBook/OnlyCompanionApp.stories.tsx
+++ b/src/components/stories/BookListItem/FulfillableBook/OnlyCompanionApp.stories.tsx
@@ -21,22 +21,22 @@ const Template: Story<{ book: AnyBook }> = args => <BookListItem {...args} />;
 const redirectEpub = {
   ...epubFulfillmentLink,
   supportLevel: "redirect"
-};
+} as const;
 
 const redirectAxisNow = {
   ...axisnowFulfillmentLink,
   supportLevel: "redirect"
-};
+} as const;
 
 const redirectExternal = {
   ...externalReadFulfillmentLink,
   supportLevel: "redirect"
-};
+} as const;
 
 const redirectPdf = {
   ...pdfFulfillmentLink,
   supportLevel: "redirect"
-};
+} as const;
 
 export const DownloadEpub = Template.bind({});
 DownloadEpub.args = {
@@ -52,7 +52,8 @@ WithAvailability.args = {
     ...fulfillableBook,
     fulfillmentLinks: [redirectEpub],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };
@@ -64,7 +65,8 @@ AxisNow.args = {
     ...fulfillableBook,
     fulfillmentLinks: [redirectAxisNow],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };
@@ -76,7 +78,8 @@ ExternalReadOnline.args = {
     ...fulfillableBook,
     fulfillmentLinks: [redirectExternal],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };
@@ -87,7 +90,8 @@ MultipleOptions.args = {
   book: {
     ...fulfillableBook,
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     },
     fulfillmentLinks: [redirectExternal, redirectEpub, redirectPdf]
   }
@@ -100,7 +104,8 @@ WithoutRevokeUrl.args = {
     ...fulfillableBook,
     fulfillmentLinks: [redirectPdf],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     },
     revokeUrl: null
   }
@@ -112,7 +117,8 @@ Unsupported.args = {
   book: {
     ...unsupportedBook,
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };

--- a/src/components/stories/BookListItem/FulfillableBook/PrefersCompanionApp.stories.tsx
+++ b/src/components/stories/BookListItem/FulfillableBook/PrefersCompanionApp.stories.tsx
@@ -21,22 +21,22 @@ const Template: Story<{ book: AnyBook }> = args => <BookListItem {...args} />;
 const redirectEpub = {
   ...epubFulfillmentLink,
   supportLevel: "redirect-and-show"
-};
+} as const;
 
 const redirectAxisNow = {
   ...axisnowFulfillmentLink,
   supportLevel: "redirect-and-show"
-};
+} as const;
 
 const redirectExternal = {
   ...externalReadFulfillmentLink,
   supportLevel: "redirect-and-show"
-};
+} as const;
 
 const redirectPdf = {
   ...pdfFulfillmentLink,
   supportLevel: "redirect-and-show"
-};
+} as const;
 
 export const DownloadEpub = Template.bind({});
 DownloadEpub.args = {
@@ -52,7 +52,8 @@ WithAvailability.args = {
     ...fulfillableBook,
     fulfillmentLinks: [redirectEpub],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };
@@ -64,7 +65,8 @@ AxisNow.args = {
     ...fulfillableBook,
     fulfillmentLinks: [redirectAxisNow],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };
@@ -76,7 +78,8 @@ ExternalReadOnline.args = {
     ...fulfillableBook,
     fulfillmentLinks: [redirectExternal],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };
@@ -87,7 +90,8 @@ MultipleOptions.args = {
   book: {
     ...fulfillableBook,
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     },
     fulfillmentLinks: [redirectExternal, redirectEpub, redirectPdf]
   }
@@ -100,7 +104,8 @@ WithoutRevokeUrl.args = {
     ...fulfillableBook,
     fulfillmentLinks: [redirectPdf],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     },
     revokeUrl: null
   }
@@ -112,7 +117,8 @@ Unsupported.args = {
   book: {
     ...unsupportedBook,
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };

--- a/src/components/stories/BookListItem/FulfillableBook/PrefersWebApp.stories.tsx
+++ b/src/components/stories/BookListItem/FulfillableBook/PrefersWebApp.stories.tsx
@@ -36,7 +36,8 @@ WithAvailability.args = {
   book: {
     ...fulfillableBook,
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };
@@ -48,7 +49,8 @@ AxisNow.args = {
     ...fulfillableBook,
     fulfillmentLinks: [axisnowFulfillmentLink],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };
@@ -60,7 +62,8 @@ ExternalReadOnline.args = {
     ...fulfillableBook,
     fulfillmentLinks: [externalReadFulfillmentLink],
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };
@@ -71,7 +74,8 @@ MultipleOptions.args = {
   book: {
     ...fulfillableBook,
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     },
     fulfillmentLinks: [
       externalReadFulfillmentLink,
@@ -87,7 +91,8 @@ WithoutRevokeUrl.args = {
   book: {
     ...fulfillableBook,
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     },
     revokeUrl: null
   }
@@ -99,7 +104,8 @@ Unsupported.args = {
   book: {
     ...unsupportedBook,
     availability: {
-      until: "Jun 10 1980"
+      until: "Jun 10 1980",
+      status: "available"
     }
   }
 };

--- a/src/components/stories/BookListItem/OnHoldBook.stories.tsx
+++ b/src/components/stories/BookListItem/OnHoldBook.stories.tsx
@@ -21,7 +21,8 @@ WithAvailability.args = {
   book: {
     ...onHoldBook,
     availability: {
-      until: "10/20/1980"
+      until: "10/20/1980",
+      status: "available"
     }
   }
 };

--- a/src/config/fetch-config.d.ts
+++ b/src/config/fetch-config.d.ts
@@ -1,0 +1,4 @@
+import { AppConfig } from "interfaces";
+
+declare function getAppConfig(configFileSetting: string): Promise<AppConfig>;
+export default getAppConfig;

--- a/src/dataflow/download.ts
+++ b/src/dataflow/download.ts
@@ -1,13 +1,13 @@
 import fetchWithHeaders from "dataflow/fetch";
 import download from "downloadjs";
 import { ServerError } from "errors";
-import { OPDS1 } from "interfaces";
+import { DownloadMediaType } from "types/opds1";
 import { generateFilename, typeMap } from "utils/file";
 
 export default async function downloadFile(
   url: string,
   title: string,
-  type: OPDS1.AnyBookMediaType,
+  type: DownloadMediaType,
   token?: string
 ) {
   const response = await fetchWithHeaders(url, token);
@@ -35,7 +35,7 @@ export default async function downloadFile(
 async function downloadBlob(
   response: Response,
   title: string,
-  type: OPDS1.AnyBookMediaType
+  type: DownloadMediaType
 ) {
   const blob = await response.blob();
   const extension = typeMap[type]?.extension ?? "";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -186,7 +186,7 @@ export type ReservedBook = Book<{
 
 export type FulfillableBook = Book<{
   status: "fulfillable";
-  fulfillmentLinks: FulfillmentLink[];
+  fulfillmentLinks: readonly FulfillmentLink[];
   revokeUrl: string | null;
 }>;
 

--- a/src/test-utils/fixtures/book.ts
+++ b/src/test-utils/fixtures/book.ts
@@ -211,12 +211,12 @@ export const externalReadFulfillmentLink: FulfillmentLink = {
   url: "/read-online"
 };
 
-export const fulfillableBook: FulfillableBook = {
+export const fulfillableBook = {
   ...book,
   status: "fulfillable",
   revokeUrl: "/revoke",
   fulfillmentLinks: [epubFulfillmentLink]
-};
+} as const;
 
 export const unsupportedBook: UnsupportedBook = {
   ...book,

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -6,6 +6,7 @@ import {
   MediaSupportLevel,
   OPDS1
 } from "interfaces";
+import { DownloadMediaType } from "types/opds1";
 import { bookIsAudiobook } from "utils/book";
 import { APP_CONFIG, AXISNOW_DECRYPT } from "utils/env";
 import { typeMap } from "utils/file";
@@ -28,7 +29,7 @@ import { typeMap } from "utils/file";
 export type DownloadFulfillment = {
   type: "download";
   id: string;
-  contentType: OPDS1.AnyBookMediaType;
+  contentType: DownloadMediaType;
   getUrl: GetUrlWithIndirection;
   buttonLabel: string;
 };
@@ -141,7 +142,7 @@ const constructGetUrl = (
   indirectionType: OPDS1.IndirectAcquisitionType | undefined,
   contentType: OPDS1.AnyBookMediaType,
   url: string
-): GetUrlWithIndirection => async (catalogUrl: string, token: string) => {
+): GetUrlWithIndirection => async (catalogUrl: string, token?: string) => {
   /**
    * If there is OPDS Entry Indirection, we fetch the actual link
    * from within an entry
@@ -164,7 +165,7 @@ const constructGetUrl = (
   return url;
 };
 
-export function dedupeLinks(links: FulfillmentLink[]) {
+export function dedupeLinks(links: readonly FulfillmentLink[]) {
   return links.reduce<FulfillmentLink[]>((uniqueArr, current) => {
     const isDup = uniqueArr.find(
       uniqueLink => uniqueLink.contentType === current.contentType
@@ -193,7 +194,9 @@ export function getAppSupportLevel(
 /**
  * Check if any of the links is redirect or redirect-and-show support level
  */
-export function shouldRedirectToCompanionApp(links: FulfillmentLink[]) {
+export function shouldRedirectToCompanionApp(
+  links: readonly FulfillmentLink[]
+) {
   return links.reduce((prev, link) => {
     if (prev) return true;
     const supportLevel = link.supportLevel;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This is a typescript option that was disabled when we began pulling in code from opds-web-client. This PR re-enables it to bring runtime safety guarantees for the future.