### PR TITLE
4.2.0 to dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## CHANGELOG
 
+### UNRELEASED CHANGES
+
 ### 4.2.0
 - Fix: The `open_book` event is now tracked by sending a `GET` request to the CM url instead of a `PUT` request, which was not accepted.
 - Add: Button to go back to auth selection from basic auth if multiple methods are present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGELOG
 
-### UNRELEASED CHANGES
+### 4.2.0
 - Fix: The `open_book` event is now tracked by sending a `GET` request to the CM url instead of a `PUT` request, which was not accepted.
 - Add: Button to go back to auth selection from basic auth if multiple methods are present.
 - Fix: Refactor See More card to use the same sizing and aspect ratio of the book cover images.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-patron-web",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-patron-web",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "patron UI for Circulation Manager",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This bumps the changelog and version so we can merge 4.2.0 from `dev` to `qa`