### PR TITLE
[SIMPLY-3496] 401 page is flashed during login redirection in CPW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+
 - Documentation: update README.
-- Add: Support using a library registry in the CONFIG_FILE so that the community deployment can use the SimplyE library registry to display all libraries. 
+- Add: Support using a library registry in the CONFIG_FILE so that the community deployment can use the SimplyE library registry to display all libraries.
 
 - Add: Include browsing history in breadcrumbs
 - Add: Add catalog button on openE home page
 - Fix: Protect against invalid redirect uris caused by mismatch in hydration.
 - Fix: Improve the appearance of home page book thumbnails for larger viewports
 - tests: Add a Github Workflow to trigger integration tests in NYPL-Simplified/integration-tests-web.
+- Fix: Improve UI in cases where server throws a 401 error
 
 ### 4.2.0
 

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import extractParam from "dataflow/utils";
 import { OPDS1 } from "interfaces";
+import { PageLoader } from "components/LoadingIndicator";
 
 const ErrorComponent: React.FC<{ info?: OPDS1.ProblemDocument }> = ({
   info
@@ -16,21 +17,29 @@ const ErrorComponent: React.FC<{ info?: OPDS1.ProblemDocument }> = ({
   const library = extractParam(router.query, "library");
 
   return (
-    <div
-      sx={{
-        p: [3, 4]
-      }}
-    >
-      <H1>
-        {status} Error: {title}
-      </H1>
-      <p>
-        {detail && `${detail}`} <br />
-      </p>
-      <Link href={`/${library}`}>
-        <a>Return Home</a>
-      </Link>
-    </div>
+    //It isn't necessary to show an error page for 401 (Unauthorized) errors since the user will be redirected to the login page
+    //Instead, we display a PageLoader to avoid the undesirable display of an error screen while the user waits for that redirect to occur
+    <>
+      {status === 401 ? (
+        <PageLoader />
+      ) : (
+        <div
+          sx={{
+            p: [3, 4]
+          }}
+        >
+          <H1>
+            {status} Error: {title}
+          </H1>
+          <p>
+            {detail && `${detail}`} <br />
+          </p>
+          <Link href={`/${library}`}>
+            <a>Return Home</a>
+          </Link>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/__tests__/Error.test.tsx
+++ b/src/components/__tests__/Error.test.tsx
@@ -17,3 +17,14 @@ test("renders error info", () => {
     utils.getByText("The requested url is not available")
   ).toBeInTheDocument();
 });
+
+test("renders page loader when error code is 401", () => {
+  const error = {
+    status: 401,
+    title: "Invalid credentials",
+    detail: "A valid library card barcode number and PIN are required."
+  };
+  render(<Error info={error} />);
+  const headingEl = document.querySelector("h2");
+  expect(headingEl).toHaveTextContent("Loading...");
+});


### PR DESCRIPTION
Display a page loader instead of an error screen when a 401 is caught.

https://jira.nypl.org/browse/SIMPLY-3496
