### PR TITLE
4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### UNRELEASED CHANGES
 
+### 4.3.0
+
 - Documentation: update README.
 - Add: Support using a library registry in the CONFIG_FILE so that the community deployment can use the SimplyE library registry to display all libraries.
-
 - Add: Include browsing history in breadcrumbs
 - Add: Add catalog button on openE home page
 - Fix: Protect against invalid redirect uris caused by mismatch in hydration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-patron-web",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-patron-web",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "patron UI for Circulation Manager",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Releases version 4.3.0 with the following updates:

- Documentation: update README.
- Add: Support using a library registry in the CONFIG_FILE so that the community deployment can use the SimplyE library registry to display all libraries.
- Add: Include browsing history in breadcrumbs
- Add: Add catalog button on openE home page
- Fix: Protect against invalid redirect uris caused by mismatch in hydration.
- Fix: Improve the appearance of home page book thumbnails for larger viewports
- tests: Add a Github Workflow to trigger integration tests in NYPL-Simplified/integration-tests-web.
- Fix: Improve UI in cases where server throws a 401 error