### PR TITLE
[SIMPLY-3466] Login Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### UNRELEASED CHANGES
 
+- Fix: Use `window.history.replaceState` to strip the url hash after login instead of Next.js's `router.replace`. This fixes a bug where render would fail after initial login.
 
 ### 4.3.0
 

--- a/next.config.js
+++ b/next.config.js
@@ -93,6 +93,7 @@ const config = {
     AXISNOW_DECRYPT,
     APP_CONFIG: JSON.stringify(APP_CONFIG)
   },
+  productionBrowserSourceMaps: true,
   generateBuildId: async () => BUILD_ID,
   webpack: (config, { dev, isServer, _defaultLoaders, webpack }) => {
     console.log(

--- a/src/auth/useCredentials.ts
+++ b/src/auth/useCredentials.ts
@@ -136,9 +136,10 @@ function lookForSamlCredentials(
     if (!IS_SERVER && typeof window !== "undefined") {
       // clear the browser query using replaceState
       const url = new URL(window.location.href);
-      if (url.searchParams.has(SAML_LOGIN_QUERY_PARAM))
+      if (url.searchParams.has(SAML_LOGIN_QUERY_PARAM)) {
         url.searchParams.delete(SAML_LOGIN_QUERY_PARAM);
-      window.history.replaceState(null, document.title, url.toString());
+        window.history.replaceState(null, document.title, url.toString());
+      }
     }
 
     return {

--- a/src/auth/useCredentials.ts
+++ b/src/auth/useCredentials.ts
@@ -115,8 +115,10 @@ function lookForCleverCredentials(): AuthCredentials | undefined {
           .split("&")[0];
         const token = `Bearer ${accessToken}`;
 
-        // clear the url hash
-        removeUrlHash();
+        // clear the url hash with replaceState
+        const url = new URL(window.location.href);
+        url.hash = "";
+        window.history.replaceState(null, document.title, url.toString());
 
         return { token, methodType: OPDS1.CleverAuthType };
       }
@@ -130,21 +132,16 @@ function lookForSamlCredentials(
 ): AuthCredentials | undefined {
   const { access_token: samlAccessToken } = router.query;
   if (samlAccessToken) {
-    // clear the browser query
-    removeUrlHash();
+    if (!IS_SERVER && typeof window !== "undefined") {
+      // clear the browser query using replaceState
+      const url = new URL(window.location.href);
+      url.searchParams.delete("access_token");
+      window.history.replaceState(null, document.title, url.toString());
+    }
+
     return {
       token: `Bearer ${samlAccessToken}`,
       methodType: OPDS1.SamlAuthType
     };
-  }
-}
-
-function removeUrlHash() {
-  if (!IS_SERVER && typeof window !== "undefined") {
-    const uri = window.location.toString();
-    if (uri.indexOf("#") > 0) {
-      const cleanUri = uri.substring(0, uri.indexOf("#"));
-      window.history.replaceState({}, document.title, cleanUri);
-    }
   }
 }

--- a/src/auth/useCredentials.ts
+++ b/src/auth/useCredentials.ts
@@ -3,6 +3,7 @@ import Cookie from "js-cookie";
 import { AuthCredentials, OPDS1 } from "interfaces";
 import { IS_SERVER } from "utils/env";
 import { NextRouter, useRouter } from "next/router";
+import { SAML_LOGIN_QUERY_PARAM } from "utils/constants";
 
 /**
  * This hook:
@@ -130,12 +131,13 @@ function lookForCleverCredentials(): AuthCredentials | undefined {
 function lookForSamlCredentials(
   router: NextRouter
 ): AuthCredentials | undefined {
-  const { access_token: samlAccessToken } = router.query;
+  const { [SAML_LOGIN_QUERY_PARAM]: samlAccessToken } = router.query;
   if (samlAccessToken) {
     if (!IS_SERVER && typeof window !== "undefined") {
       // clear the browser query using replaceState
       const url = new URL(window.location.href);
-      url.searchParams.delete("access_token");
+      if (url.searchParams.has(SAML_LOGIN_QUERY_PARAM))
+        url.searchParams.delete(SAML_LOGIN_QUERY_PARAM);
       window.history.replaceState(null, document.title, url.toString());
     }
 

--- a/src/components/context/__tests__/UserContext.test.tsx
+++ b/src/components/context/__tests__/UserContext.test.tsx
@@ -57,6 +57,10 @@ test("does not fetch loans if no credentials are present", () => {
   expect(fetchMock).toHaveBeenCalledTimes(0);
 });
 
+const mockReplace = jest.fn(() => {
+  window.location.hash = "";
+});
+
 const replaceStateSpy = jest.spyOn(window.history, "replaceState");
 
 test("extracts clever tokens from the url", () => {
@@ -94,8 +98,15 @@ test("extracts clever tokens from the url", () => {
   );
 });
 
-test.only("extracts SAML tokens from the url", () => {
+test("extracts SAML tokens from the url", () => {
+  // we have to mock the token in the router spy and also in
+  // the url
+  const url = new URL(window.location.href);
+  url.searchParams.set("access_token", "saml-token");
+  delete (window as any).location;
+  window.location = url as any;
   useRouterSpy.mockReturnValue({
+    replace: mockReplace,
     query: { access_token: "saml-token" }
   } as any);
   renderUserContext();
@@ -122,7 +133,6 @@ test.only("extracts SAML tokens from the url", () => {
     expect.anything()
   );
 
-  expect(replaceStateSpy).toHaveBeenCalledTimes(1);
   expect(replaceStateSpy).toHaveBeenCalledWith(
     null,
     "",

--- a/src/components/context/__tests__/UserContext.test.tsx
+++ b/src/components/context/__tests__/UserContext.test.tsx
@@ -57,14 +57,11 @@ test("does not fetch loans if no credentials are present", () => {
   expect(fetchMock).toHaveBeenCalledTimes(0);
 });
 
-const mockReplace = jest.fn(() => {
-  window.location.hash = "";
-});
+const replaceStateSpy = jest.spyOn(window.history, "replaceState");
 
 test("extracts clever tokens from the url", () => {
   window.location.hash = "#access_token=fry6H3" as any;
 
-  useRouterSpy.mockReturnValue({ replace: mockReplace, query: {} } as any);
   renderUserContext();
 
   expect(mockSWR).toHaveBeenCalledWith(
@@ -89,17 +86,16 @@ test("extracts clever tokens from the url", () => {
   );
 
   // mock the router
-  expect(mockReplace).toHaveBeenCalledTimes(1);
-  expect(mockReplace).toHaveBeenCalledWith(
-    "http://test-domain.com/",
-    undefined,
-    { shallow: true }
+  expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+  expect(replaceStateSpy).toHaveBeenCalledWith(
+    null,
+    "",
+    "http://test-domain.com/"
   );
 });
 
-test("extracts SAML tokens from the url", () => {
+test.only("extracts SAML tokens from the url", () => {
   useRouterSpy.mockReturnValue({
-    replace: mockReplace,
     query: { access_token: "saml-token" }
   } as any);
   renderUserContext();
@@ -126,10 +122,11 @@ test("extracts SAML tokens from the url", () => {
     expect.anything()
   );
 
-  expect(mockReplace).toHaveBeenCalledWith(
-    "http://test-domain.com/",
-    undefined,
-    { shallow: true }
+  expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+  expect(replaceStateSpy).toHaveBeenCalledWith(
+    null,
+    "",
+    "http://test-domain.com/"
   );
 });
 

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -22,7 +22,7 @@ Error.getInitialProps = ({ res, err }) => {
   return {
     errorInfo: {
       status: statusCode,
-      title: "Something went wrong",
+      title: "Something went wrong rendering the page.",
       detail: "An unexpected error occurred."
     }
   };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,3 +5,4 @@
 export const DEFAULT_AVAILABILITY = "available";
 
 export const LOGIN_REDIRECT_QUERY_PARAM = "nextUrl";
+export const SAML_LOGIN_QUERY_PARAM = "access_token";


### PR DESCRIPTION
There was an undefined error when logging in via clever sometimes. https://jira.nypl.org/browse/SIMPLY-3466 .

I'm not sure exactly what the underlying bug was, but it had to do with how we were removing the hash parameter from the url after logging in. In the end I decided to swap use of `window.history.replaceState` instead of `router.replace` from next.js because I saw that line in the stack trace of the error, which somehow was only happening in production. This seems to have resolved the issue.